### PR TITLE
shared: add logger

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -8,5 +8,15 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1 h1:KwuLovgQPcdjNMfFt9OhUd9a
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 h1:PZV5W8yk4OtH1JAuhV2PXwwO9v5G5Aoj+eMCn4T+1Kc=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.17/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -65,6 +65,9 @@ var (
 	// One way you can use it - to have this region in the logs, CloudWatch.
 	WithAWSRegion = shared.WithAWSRegion
 
+	// WithLogger sets logger
+	WithLogger = shared.WithLogger
+
 	// WithNodesListUpdatePeriod configures how often update list of nodes, while requests are running
 	WithNodesListUpdatePeriod = shared.WithNodesListUpdatePeriod
 

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -67,6 +67,9 @@ var (
 	// One way you can use it - to have this region in the logs, CloudWatch.
 	WithAWSRegion = shared.WithAWSRegion
 
+	// WithLogger sets logger
+	WithLogger = shared.WithLogger
+
 	// WithNodesListUpdatePeriod configures how often update list of nodes, while requests are running
 	WithNodesListUpdatePeriod = shared.WithNodesListUpdatePeriod
 

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -1,3 +1,8 @@
 module github.com/scylladb/alternator-client-golang/shared
 
 go 1.24.0
+
+require (
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+)

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -1,0 +1,4 @@
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=

--- a/shared/logx/logx.go
+++ b/shared/logx/logx.go
@@ -1,0 +1,86 @@
+// Package logx provides a lightweight, implementation-agnostic logging API.
+//
+// It defines a universal Logger interface with support for structured logging,
+// log levels (debug, info, warn, error), and contextual attributes.
+// Implementations can wrap any underlying logging library while exposing
+// a consistent API to application code.
+//
+// The package provides:
+//   - Level: predefined logging severity levels.
+//   - Attr: a key/value pair for structured log fields.
+//   - A: helper function to quickly create an Attr.
+//   - Noop: a Logger implementation that discards all log messages.
+package logx
+
+// Level represents the severity of a log message.
+type Level int
+
+const (
+	// Debug is a level for messages for verbose output useful in development.
+	Debug Level = iota
+	// Info is a level for informational messages for normal application operation.
+	Info
+	// Warn is a level for unexpected situations that are recoverable.
+	Warn
+	// Error is a level for problems that require attention.
+	Error
+)
+
+// Attr represents a key/value pair used for structured logging.
+type Attr struct {
+	Key   string // The attribute name.
+	Value any    // The attribute value.
+}
+
+// A creates an Attr from a key and value.
+func A(k string, v any) Attr { return Attr{Key: k, Value: v} }
+
+// Logger describes a universal, implementation-agnostic logging API.
+type Logger interface {
+	// Log logs a message at the given severity level with optional structured attributes.
+	Log(lvl Level, msg string, attrs ...Attr)
+
+	// Debug logs a debug-level message with optional attributes.
+	Debug(msg string, attrs ...Attr)
+	// Info logs an informational message with optional attributes.
+	Info(msg string, attrs ...Attr)
+	// Warn logs a warning message with optional attributes.
+	Warn(msg string, attrs ...Attr)
+	// Error logs an error message with optional attributes.
+	Error(msg string, attrs ...Attr)
+
+	// With returns a Logger that includes the given attributes with all future log messages.
+	With(attrs ...Attr) Logger
+	// Named returns a Logger with an additional name identifier for scoping logs.
+	Named(name string) Logger
+
+	// Enabled reports whether logging is enabled for the given level.
+	Enabled(lvl Level) bool
+}
+
+// Noop is a Logger implementation that discards all log messages.
+type Noop struct{}
+
+// Log discards the log message and attributes.
+func (Noop) Log(Level, string, ...Attr) {}
+
+// Debug discards the debug message and attributes.
+func (Noop) Debug(string, ...Attr) {}
+
+// Info discards the informational message and attributes.
+func (Noop) Info(string, ...Attr) {}
+
+// Warn discards the warning message and attributes.
+func (Noop) Warn(string, ...Attr) {}
+
+// Error discards the error message and attributes.
+func (Noop) Error(string, ...Attr) {}
+
+// With returns the same Noop logger, ignoring the provided attributes.
+func (n Noop) With(...Attr) Logger { return n }
+
+// Named returns the same Noop logger, ignoring the provided name.
+func (n Noop) Named(string) Logger { return n }
+
+// Enabled always returns false, indicating logging is disabled.
+func (Noop) Enabled(Level) bool { return false }

--- a/shared/logxzap/logxzap.go
+++ b/shared/logxzap/logxzap.go
@@ -1,0 +1,143 @@
+// Package logxzap provides an implementation of the logx.Logger interface
+// backed by the Uber Zap logging library.
+//
+// It allows applications to use the generic logx logging API while leveraging
+// Zap's high-performance structured logging capabilities. This helps maintain
+// a consistent logging abstraction across different logger backends.
+//
+// The package includes:
+//   - Logger: an adapter that wraps zap.Logger and implements logx.Logger.
+//   - New: creates a Logger from an existing zap.Logger.
+//   - DefaultLogger: returns a preconfigured console logger at Debug level.
+//
+// This package is intended for use where you want to:
+//   - Keep application logging code decoupled from the underlying logging library.
+//   - Maintain structured, leveled logging with minimal overhead.
+//   - Reuse the same logging interface (logx.Logger) across different backends.
+//
+// Example:
+//
+//	import (
+//	    "github.com/scylladb/alternator-client-golang/shared/logx"
+//	    "github.com/scylladb/alternator-client-golang/shared/logxzap"
+//	)
+//
+//	func main() {
+//	    logger := logxzap.DefaultLogger()
+//	    logger.Info("Application started", logx.A("version", "1.0.0"))
+//	}
+package logxzap
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/scylladb/alternator-client-golang/shared/logx"
+)
+
+// Logger is an adapter that implements the logx.Logger interface
+// using an underlying zap.Logger instance.
+type Logger struct {
+	z *zap.Logger
+}
+
+// New creates a new Logger that wraps the given zap.Logger.
+func New(z *zap.Logger) *Logger { return &Logger{z: z} }
+
+// Log writes a log entry at the specified level with the given message
+// and optional structured attributes. If the level is disabled, the log
+// is skipped without formatting cost.
+func (l *Logger) Log(lvl logx.Level, msg string, attrs ...logx.Attr) {
+	if ce := l.z.Check(toZapLevel(lvl), msg); ce != nil {
+		ce.Write(toZapFields(attrs)...)
+	}
+}
+
+// Debug logs a message at the Debug level with optional structured attributes.
+func (l *Logger) Debug(msg string, attrs ...logx.Attr) {
+	l.Log(logx.Debug, msg, attrs...)
+}
+
+// Info logs a message at the Info level with optional structured attributes.
+func (l *Logger) Info(msg string, attrs ...logx.Attr) {
+	l.Log(logx.Info, msg, attrs...)
+}
+
+// Warn logs a message at the Warn level with optional structured attributes.
+func (l *Logger) Warn(msg string, attrs ...logx.Attr) {
+	l.Log(logx.Warn, msg, attrs...)
+}
+
+// Error logs a message at the Error level with optional structured attributes.
+func (l *Logger) Error(msg string, attrs ...logx.Attr) {
+	l.Log(logx.Error, msg, attrs...)
+}
+
+// With returns a new Logger instance that includes the given attributes
+// in all subsequent log entries.
+func (l *Logger) With(attrs ...logx.Attr) logx.Logger {
+	return &Logger{z: l.z.With(toZapFields(attrs)...)}
+}
+
+// Named returns a new Logger instance with an additional name scope.
+// The name appears in the log output and helps identify the log source.
+func (l *Logger) Named(name string) logx.Logger {
+	return &Logger{z: l.z.Named(name)}
+}
+
+// Enabled reports whether the specified log level is enabled.
+func (l *Logger) Enabled(lvl logx.Level) bool {
+	return l.z.Core().Enabled(toZapLevel(lvl))
+}
+
+// toZapLevel converts a logx.Level to the corresponding zapcore.Level.
+func toZapLevel(l logx.Level) zapcore.Level {
+	switch l {
+	case logx.Debug:
+		return zapcore.DebugLevel
+	case logx.Info:
+		return zapcore.InfoLevel
+	case logx.Warn:
+		return zapcore.WarnLevel
+	default:
+		return zapcore.ErrorLevel
+	}
+}
+
+// toZapFields converts logx.Attr values to zap.Field values.
+func toZapFields(attrs []logx.Attr) []zap.Field {
+	if len(attrs) == 0 {
+		return nil
+	}
+	fs := make([]zap.Field, 0, len(attrs))
+	for _, a := range attrs {
+		fs = append(fs, zap.Any(a.Key, a.Value))
+	}
+	return fs
+}
+
+// DefaultLogger creates a new Logger that writes to standard output
+// using zap's console encoder with ISO8601 timestamps and caller information.
+// Logging is enabled at the Debug level and above.
+func DefaultLogger() logx.Logger {
+	cfg := zapcore.EncoderConfig{
+		TimeKey:        "T",
+		LevelKey:       "L",
+		NameKey:        "N",
+		CallerKey:      "C",
+		MessageKey:     "M",
+		StacktraceKey:  "S",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+
+	consoleEncoder := zapcore.NewConsoleEncoder(cfg)
+	core := zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zap.DebugLevel)
+
+	return New(zap.New(core, zap.AddCaller()))
+}

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -45,6 +45,8 @@ func PatchBasicHTTPTransport(config ALNConfig, transport *http.Transport) {
 	}
 
 	if config.ClientCertificateSource != nil {
-		transport.TLSClientConfig.GetClientCertificate = config.ClientCertificateSource.GetClientCertificate
+		transport.TLSClientConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return config.ClientCertificateSource.GetClientCertificate(info, config.Logger)
+		}
 	}
 }


### PR DESCRIPTION
There are some parts of the code that need logging.
Before this change it was using `fmt.Print...`

This PR introduces:
1. `logx` package as implementation independent logging layer
2. `logxzap` a package that implements `logx` using `go.uber.org/zap`
3. Introduces `WithLogger` configuration to override default logger 
4. Make use of logger in different parts of the code