### PR TITLE
shared: introduce routing

### DIFF
--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -58,6 +58,9 @@ var (
 	// WithDatacenter makes DynamoDB client target only nodes from particular datacenter
 	WithDatacenter = shared.WithDatacenter
 
+	// WithRoutingScope makes DynamoDB client target only nodes from particular scope (dc, rack, cluster)
+	WithRoutingScope = shared.WithRoutingScope
+
 	// WithAWSRegion inject region into DynamoDB client, this region does not play any role
 	// One way you can use it - to have this region in the logs, CloudWatch.
 	WithAWSRegion = shared.WithAWSRegion

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -60,6 +60,9 @@ var (
 	// WithDatacenter makes DynamoDB client target only nodes from particular datacenter
 	WithDatacenter = shared.WithDatacenter
 
+	// WithRoutingScope makes DynamoDB client target only nodes from particular scope (dc, rack, cluster)
+	WithRoutingScope = shared.WithRoutingScope
+
 	// WithAWSRegion inject region into DynamoDB client, this region does not play any role
 	// One way you can use it - to have this region in the logs, CloudWatch.
 	WithAWSRegion = shared.WithAWSRegion

--- a/sdkv2/helper_test.go
+++ b/sdkv2/helper_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net/url"
 	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/aws/smithy-go"
+
+	"github.com/scylladb/alternator-client-golang/shared/rt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -29,6 +32,42 @@ var (
 )
 
 var notFoundErr = new(*smithy.OperationError)
+
+func TestRoutingFallback(t *testing.T) {
+	h, err := helper.NewHelper(
+		knownNodes,
+		helper.WithPort(httpPort),
+		helper.WithRoutingScope(rt.NewDCScope("wrongDC", rt.NewDCScope("datacenter1", nil))),
+	)
+	if err != nil {
+		t.Fatalf("failed to create alternator helper: %v", err)
+	}
+	defer h.Stop()
+
+	if err := h.CheckIfRackAndDatacenterSetCorrectly(); err != nil {
+		t.Fatalf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
+	}
+	err = h.UpdateLiveNodes()
+	if err != nil {
+		t.Fatalf("UpdateLiveNodes() unexpectedly returned an error: %v", err)
+	}
+	meetNodes := map[url.URL]struct{}{}
+	var nodesListWasUpdated bool
+	for {
+		node := h.NextNode()
+		if _, ok := meetNodes[node]; ok {
+			break
+		}
+		meetNodes[node] = struct{}{}
+		if !slices.Contains(knownNodes, node.Host) {
+			// New node was learned
+			nodesListWasUpdated = true
+		}
+	}
+	if !nodesListWasUpdated {
+		t.Fatalf("UpdateLiveNodes() did not update node list")
+	}
+}
 
 func TestCheckIfRackAndDatacenterSetCorrectly_WrongDC(t *testing.T) {
 	h, err := helper.NewHelper(knownNodes, helper.WithPort(httpPort), helper.WithDatacenter("wrongDC"))

--- a/shared/rt/routing_scope.go
+++ b/shared/rt/routing_scope.go
@@ -1,0 +1,155 @@
+// Package rt defines the configuration routing “scope” to target
+// where requests should be directed: a specific rack, a datacenter, or the
+// whole cluster. Scopes can be chained with fallbacks, e.g. Rack -> DC ->
+// Cluster, allowing the router to relax locality constraints if no suitable
+// local nodes are available.
+//
+// Each scope produces a stable, human-readable name and string form, and a
+// query fragment that can be used to filter candidate “local” nodes.
+package rt
+
+import "fmt"
+
+// Scope describes a routing locality target and how to fall back when no
+// nodes match the current scope.
+//
+// Implementations should be immutable and safe to share across goroutines.
+type Scope interface {
+	// Name returns a short, human-readable scope name (e.g. "Rack",
+	// "Datacenter", "Cluster").
+	Name() string
+
+	// String returns a descriptive representation of the scope including
+	// its parameters (e.g. "Rack(dc=us-east, rack=r1)").
+	String() string
+
+	// Fallback returns the next scope to try when the current scope yields
+	// no local nodes. If there is no broader scope to fall back to, it
+	// returns nil.
+	Fallback() Scope
+
+	// GetLocalNodesQuery returns a query string fragment identifying what
+	// counts as "local" for this scope. The format is stable and intended
+	// to be consumed by node-selection code (e.g. "dc=us-east&rack=r1",
+	// "dc=us-east", or "").
+	GetLocalNodesQuery() string
+}
+
+// RackScope targets a specific rack within a datacenter.
+//
+// Example:
+//
+//	rs := NewRackScope("us-east", "rack1", NewDCScope("us-east", NewClusterScope()))
+//
+// This will try rack1 in us-east first, then any node in us-east, then the cluster.
+type RackScope struct {
+	rack       string
+	datacenter string
+	fallback   Scope
+}
+
+// NewRackScope constructs a RackScope for the given rack and datacenter.
+// The optional fallback is consulted when no nodes match the rack.
+func NewRackScope(datacenter, rack string, fallback Scope) *RackScope {
+	return &RackScope{
+		rack:       rack,
+		datacenter: datacenter,
+		fallback:   fallback,
+	}
+}
+
+// Name implements Scope.
+func (r RackScope) Name() string {
+	return "Rack"
+}
+
+// String implements Scope.
+func (r RackScope) String() string {
+	return fmt.Sprintf("%s(dc=%s, rack=%s)", r.Name(), r.datacenter, r.rack)
+}
+
+// Fallback implements Scope.
+func (r RackScope) Fallback() Scope {
+	return r.fallback
+}
+
+// GetLocalNodesQuery implements Scope. It returns "dc=<dc>&rack=<rack>".
+func (r RackScope) GetLocalNodesQuery() string {
+	return fmt.Sprintf("dc=%s&rack=%s", r.datacenter, r.rack)
+}
+
+var _ Scope = &RackScope{}
+
+// DCScope targets all nodes within a single datacenter.
+//
+// It is typically used as a fallback for RackScope, or as a primary scope
+// when rack-level locality is not required.
+type DCScope struct {
+	datacenter string
+	fallback   Scope
+}
+
+// NewDCScope constructs a DCScope for the given datacenter. The optional
+// fallback is consulted when no nodes match the datacenter.
+func NewDCScope(datacenter string, fallback Scope) *DCScope {
+	return &DCScope{
+		datacenter: datacenter,
+		fallback:   fallback,
+	}
+}
+
+// Name implements Scope.
+func (d DCScope) Name() string {
+	return "Datacenter"
+}
+
+// String implements Scope.
+func (d DCScope) String() string {
+	return fmt.Sprintf("%s(dc=%s)", d.Name(), d.datacenter)
+}
+
+// Fallback implements Scope.
+func (d DCScope) Fallback() Scope {
+	return d.fallback
+}
+
+// GetLocalNodesQuery implements Scope. It returns "dc=<dc>".
+func (d DCScope) GetLocalNodesQuery() string {
+	return fmt.Sprintf("dc=%s", d.datacenter)
+}
+
+var _ Scope = &DCScope{}
+
+// ClusterScope targets the entire cluster, regardless of datacenter or rack.
+//
+// This is usually the terminal fallback. It has no narrower locality
+// constraints, and therefore returns an empty query string.
+type ClusterScope struct{}
+
+// NewClusterScope constructs a ClusterScope.
+func NewClusterScope() *ClusterScope {
+	return &ClusterScope{}
+}
+
+// Name implements Scope.
+func (w ClusterScope) Name() string {
+	return "Cluster"
+}
+
+// String implements Scope.
+func (w ClusterScope) String() string {
+	return "Cluster()"
+}
+
+// Fallback implements Scope. ClusterScope has no fallback and returns nil.
+func (w ClusterScope) Fallback() Scope {
+	return nil
+}
+
+// GetLocalNodesQuery implements Scope. It returns an empty string to indicate
+// no locality filtering (entire cluster is eligible).
+func (w ClusterScope) GetLocalNodesQuery() string {
+	return ""
+}
+
+var _ Scope = &ClusterScope{}


### PR DESCRIPTION
Some of our customers wants to have routing logic with fallback. They want to target nodes from a particular rack and if rack is not available, switch to datacenter.
Or like-wise target datacenter and switch to whole cluster.

This commit introduces routing package `rt` that allows it to happen. You define routing:
```
helper.NewHelper(
  ...
  helper.WithRoutingScope(rt.NewDCScope("wrongDC", rt.NewDCScope("datacenter1", nil)))
  ...
  )
```
And it automagically works when helper reads nodes list.

Closes: https://github.com/scylladb/alternator-client-golang/issues/6