### PR TITLE
Deprecate `withRack` and `WithDatacenter`

### DIFF
--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -53,9 +53,11 @@ var (
 	WithPort = shared.WithPort
 
 	// WithRack makes DynamoDB client target only nodes from particular rack
+	// Deprecated: use WithRoutingScope(rt.Rackcope("dc1", "rack1", nil)) instead
 	WithRack = shared.WithRack
 
 	// WithDatacenter makes DynamoDB client target only nodes from particular datacenter
+	// Deprecated: use WithRoutingScope(rt.DCScope("dc1", nil)) instead
 	WithDatacenter = shared.WithDatacenter
 
 	// WithRoutingScope makes DynamoDB client target only nodes from particular scope (dc, rack, cluster)

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -55,9 +55,11 @@ var (
 	WithPort = shared.WithPort
 
 	// WithRack makes DynamoDB client target only nodes from particular rack
+	// Deprecated: use WithRoutingScope(rt.Rackcope("dc1", "rack1", nil)) instead
 	WithRack = shared.WithRack
 
 	// WithDatacenter makes DynamoDB client target only nodes from particular datacenter
+	// Deprecated: use WithRoutingScope(rt.DCScope("dc1", nil)) instead
 	WithDatacenter = shared.WithDatacenter
 
 	// WithRoutingScope makes DynamoDB client target only nodes from particular scope (dc, rack, cluster)

--- a/shared/config.go
+++ b/shared/config.go
@@ -133,6 +133,7 @@ func WithPort(port int) Option {
 }
 
 // WithRack makes DynamoDB client target only nodes from particular rack
+// Deprecated: use WithRoutingScope(rt.Rackcope("dc1", "rack1", nil)) instead
 func WithRack(rack string) Option {
 	return func(config *Config) {
 		if config.Datacenter == "" {
@@ -143,6 +144,7 @@ func WithRack(rack string) Option {
 }
 
 // WithDatacenter makes DynamoDB client target only nodes from particular datacenter
+// Deprecated: use WithRoutingScope(rt.DCScope("dc1", nil)) instead
 func WithDatacenter(dc string) Option {
 	return func(config *Config) {
 		config.Datacenter = dc


### PR DESCRIPTION
Once `WithRoutingScope` was [introduced](https://github.com/scylladb/alternator-client-golang/pull/5) there is no need to maintain old routing options.