### PR TITLE
Add WithAWSConfigOptions and helper.WithHTTPClientTimeout

### DIFF
--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -113,7 +113,19 @@ var (
 	// WithHTTPTransportWrapper provides ability to control http transport
 	// For testing purposes only, don't use it on production
 	WithHTTPTransportWrapper = shared.WithHTTPTransportWrapper
+
+	// WithHTTPClientTimeout controls timeout for HTTP requests
+	WithHTTPClientTimeout = shared.WithHTTPClientTimeout
 )
+
+// WithAWSConfigOptions lets callers mutate the generated aws.Config before it is used by the SDK.
+func WithAWSConfigOptions(options ...func(*aws.Config)) Option {
+	return func(config *shared.Config) {
+		for _, option := range options {
+			config.AWSConfigOptions = append(config.AWSConfigOptions, option)
+		}
+	}
+}
 
 // AlternatorNodesSource an interface for nodes list provider
 type AlternatorNodesSource interface {
@@ -223,6 +235,15 @@ func (lb *Helper) awsConfig() (aws.Config, error) {
 
 	cfg.HTTPClient = &http.Client{
 		Transport: lb.wrapHTTPTransport(shared.NewHTTPTransport(lb.cfg)),
+		Timeout:   lb.cfg.HTTPClientTimeout,
+	}
+
+	customizers, err := shared.ConvertToAWSConfigOptions[func(*aws.Config)](lb.cfg.AWSConfigOptions)
+	if err != nil {
+		return aws.Config{}, err
+	}
+	for _, opt := range customizers {
+		opt(&cfg)
 	}
 	return cfg, nil
 }
@@ -241,6 +262,7 @@ func (lb *Helper) newAWSSession() (*session.Session, error) {
 // Update takes config of current helper, updates its config and creates a new helper with updated config
 func (lb *Helper) Update(opts ...Option) *Helper {
 	cfg := lb.cfg
+	cfg.AWSConfigOptions = shared.CloneAWSConfigOptions(cfg.AWSConfigOptions)
 	for _, opt := range opts {
 		opt(&cfg)
 	}

--- a/shared/config_unit_test.go
+++ b/shared/config_unit_test.go
@@ -1,0 +1,55 @@
+package shared
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConvertToAWSConfigOptions(t *testing.T) {
+	orig := []string{"some-string", "other-string"}
+	var arg []any
+	for _, v := range orig {
+		arg = append(arg, v)
+	}
+	t.Run("negative", func(t *testing.T) {
+		_, err := ConvertToAWSConfigOptions[float32](arg)
+		if err == nil {
+			t.Fatal("expected error, got none")
+		}
+	})
+	t.Run("positive", func(t *testing.T) {
+		res, err := ConvertToAWSConfigOptions[string](arg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(res) != len(orig) {
+			t.Fatalf("want %d values, got %d", len(orig), len(res))
+		}
+
+		for i := range res {
+			if res[i] != orig[i] {
+				t.Fatalf("want %s, got %s", orig[i], res[i])
+			}
+		}
+	})
+}
+
+func TestWithHTTPClientTimeout(t *testing.T) {
+	cfg := NewDefaultConfig()
+	timeout := 3 * time.Second
+
+	WithHTTPClientTimeout(timeout)(cfg)
+	if cfg.HTTPClientTimeout != timeout {
+		t.Fatalf("Config HTTPClientTimeout = %s, want %s", cfg.HTTPClientTimeout, timeout)
+	}
+
+	alnCfg := NewDefaultALNConfig()
+	for _, opt := range cfg.ToALNOptions() {
+		opt(&alnCfg)
+	}
+
+	if alnCfg.HTTPClientTimeout != timeout {
+		t.Fatalf("ALNConfig HTTPClientTimeout = %s, want %s", alnCfg.HTTPClientTimeout, timeout)
+	}
+}


### PR DESCRIPTION
Both options are added to target particular case of setting timeout and retry, 
but `WithAWSConfigOption` goes far beyond that. 
For not there is no validation, so it opens a path for misconfigurations.