### PR TITLE
Add query plan

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -13,6 +13,7 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7 h1:Is2tPmieqGS2edBnmOJIbdv
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7/go.mod h1:F1i5V5421EGci570yABvpIXgRIBPb5JM+lSkHF6Dq5w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.9 h1:Mv4Bc0mWmv6oDuSWTKnk+wgeqPL5DRFu5bQL9BGPQ8Y=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.9/go.mod h1:IKlKfRppK2a1y0gy1yH6zD+yX5uplJ6UuPlgd48dJiQ=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.14 h1:WZVR5DbDgxzA0BJeudId89Kmgy6DIU4ORpxwsVHz0qA=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.14/go.mod h1:Dadl9QO0kHgbrH1GRqGiZdYtW5w+IXXaBNCHTIaheM4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13 h1:a+8/MLcWlIxo1lF9xaGt3J/u3yOZx+CdSveSNwjhD40=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13/go.mod h1:oGnKwIYZ4XttyU2JWxFrwvhF6YKiK/9/wmE3v3Iu9K8=
@@ -30,14 +31,15 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.3/go.mod h1:
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.13 h1:FScsqdRyKFkw3u2ysLeWC0dbaz9I+g0xJ1JlQpH6bPo=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.13/go.mod h1:wkhwIaGltEuG4SRwNzPiJmf/tDp+yL5ym55Lt4bheno=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.14/go.mod h1:yLon9pByjyB6JZq5IAmwnjE3ObIhD0QibfRWH7tUhLU=
-github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.14/go.mod h1:Dadl9QO0kHgbrH1GRqGiZdYtW5w+IXXaBNCHTIaheM4=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15/go.mod h1:SwFBy2vjtA0vZbjjaFtfN045boopadnoVPhu4Fv66vY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.7 h1:mLgc5QIgOy26qyh5bvW+nDoAppxgn3J2WV3m9ewq7+8=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.7/go.mod h1:wXb/eQnqt8mDQIQTTmcw58B5mYGxzLGZGK8PWNFZ0BA=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.9 h1:5r34CgVOD4WZudeEKZ9/iKpiT6cM1JyEROpXjOcdWv8=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.9/go.mod h1:dB12CEbNWPbzO2uC6QSWHteqOg4JfBVJOojbAoAUb5I=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.14 h1:FIouAnCE46kyYqyhs0XEBDFFSREtdnr8HQuLPQPLCrY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.14/go.mod h1:UTwDc5COa5+guonQU8qBikJo1ZJ4ln2r1MkF7Dqag1E=
+github.com/aws/aws-sdk-go-v2/service/signin v1.0.2 h1:MxMBdKTYBjPQChlJhi4qlEueqB1p1KcbTEa7tD5aqPs=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.2/go.mod h1:iS6EPmNeqCsGo+xQmXv0jIMjyYtQfnwg36zl2FwEouk=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.1 h1:8JdC7Gr9NROg1Rusk25IcZeTO59zLxsKgE0gkh5O6h0=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.1/go.mod h1:qs4a9T5EMLl/Cajiw2TcbNt2UNo/Hqlyp+GiuG4CFDI=
@@ -45,6 +47,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.29.3 h1:7PKX3VYsZ8LUWceVRuv0+PU+E7Ot
 github.com/aws/aws-sdk-go-v2/service/sso v1.29.3/go.mod h1:Ql6jE9kyyWI5JHn+61UT/Y5Z0oyVJGmgmJbZD5g4unY=
 github.com/aws/aws-sdk-go-v2/service/sso v1.29.6 h1:A1oRkiSQOWstGh61y4Wc/yQ04sqrQZr1Si/oAXj20/s=
 github.com/aws/aws-sdk-go-v2/service/sso v1.29.6/go.mod h1:5PfYspyCU5Vw1wNPsxi15LZovOnULudOQuVxphSflQA=
+github.com/aws/aws-sdk-go-v2/service/sso v1.30.5 h1:ksUT5KtgpZd3SAiFJNJ0AFEJVva3gjBmN7eXUZjzUwQ=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.5/go.mod h1:av+ArJpoYf3pgyrj6tcehSFW+y9/QvAY8kMooR9bZCw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1 h1:KwuLovgQPcdjNMfFt9OhUd9a2OwcOKhxfvF4glTzLuA=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
@@ -52,6 +55,7 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.34.4 h1:e0XBRn3AptQotkyBFrHAxFB8
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.34.4/go.mod h1:XclEty74bsGBCr1s0VSaA11hQ4ZidK4viWK7rRfO88I=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.1 h1:5fm5RTONng73/QA73LhCNR7UT9RpFH3hR6HWL6bIgVY=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.1/go.mod h1:xBEjWD13h+6nq+z4AkqSfSvqRKFgDIQeaMguAJndOWo=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.10 h1:GtsxyiF3Nd3JahRBJbxLCCdYW9ltGQYrFWg8XdkGDd8=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.10/go.mod h1:/j67Z5XBVDx8nZVp9EuFM9/BS5dvBznbqILGuu73hug=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 h1:PZV5W8yk4OtH1JAuhV2PXwwO9v5G5Aoj+eMCn4T+1Kc=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.17/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
@@ -59,9 +63,9 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.38.4 h1:PR00NXRYgY4FWHqOGx3fC3lhVKjs
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.4/go.mod h1:Z+Gd23v97pX9zK97+tX4ppAgqCt3Z2dIXB02CtBncK8=
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6 h1:p3jIvqYwUZgu/XYeI48bJxOhvm47hZb5HUQ0tn6Q9kA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6/go.mod h1:WtKK+ppze5yKPkZ0XwqIVWD4beCwv056ZbPQNoeHqM8=
+github.com/aws/aws-sdk-go-v2/service/sts v1.41.2 h1:a5UTtD4mHBU3t0o6aHQZFJTNKVfxFWfPX7J0Lr7G+uY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.2/go.mod h1:6TxbXoDSgBQ225Qd8Q+MbxUxUh6TtNKwbRt/EPS9xso=
 github.com/aws/smithy-go v1.23.2/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
-github.com/aws/aws-sdk-go-v2/service/sts v1.41.2/go.mod h1:6TxbXoDSgBQ225Qd8Q+MbxUxUh6TtNKwbRt/EPS9xso=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/sdkv1/helper_test.go
+++ b/sdkv1/helper_test.go
@@ -167,6 +167,7 @@ func TestKeyLogWriter(t *testing.T) {
 		helper.WithIgnoreServerCertificateError(true),
 		helper.WithNodesListUpdatePeriod(0),
 		helper.WithIdleNodesListUpdatePeriod(0),
+		helper.WithCredentials("whatever", "secret"),
 	}
 	t.Run("AlternatorLiveNodes", func(t *testing.T) {
 		keyWriter := &KeyWriter{}
@@ -199,9 +200,12 @@ func TestKeyLogWriter(t *testing.T) {
 			t.Fatalf("failed to create DynamoDB client: %v", err)
 		}
 
-		_, _ = ddb.DeleteTable(&dynamodb.DeleteTableInput{
+		_, err = ddb.DeleteTable(&dynamodb.DeleteTableInput{
 			TableName: aws.String("table-that-does-not-exist"),
 		})
+		if err != nil && !errors.As(err, notFoundErr) {
+			t.Fatalf("unexpected operation error: %v", err)
+		}
 
 		if len(keyWriter.keyData) == 0 {
 			t.Fatalf("keyData should not be empty")

--- a/shared/errs/errors.go
+++ b/shared/errs/errors.go
@@ -1,0 +1,14 @@
+// Package errs contains all the errors shared between two clients
+package errs
+
+import "errors"
+
+var (
+	// ErrCtxHasNoQueryPlan is an error signaling that request context does not have query plan assigned to it
+	// which is a bug and needs to be reported
+	ErrCtxHasNoQueryPlan = errors.New("no query plan found on the context, it is a bug, please report")
+	// ErrCtxHasNoNode is a similar error regarding a target node
+	ErrCtxHasNoNode = errors.New("no node found on the context, it is a bug, please report")
+	// ErrQueryPlanExhausted signals that query plan has come to an end and has no more nodes in it
+	ErrQueryPlanExhausted = errors.New("query plan has been exhausted")
+)

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -2,6 +2,9 @@ module github.com/scylladb/alternator-client-golang/shared
 
 go 1.24.0
 
-require go.uber.org/zap v1.27.1
+require (
+	go.uber.org/zap v1.27.1
+	github.com/aws/smithy-go v1.23.2
+)
 
 require go.uber.org/multierr v1.11.0 // indirect

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -36,6 +36,18 @@ type AlternatorLiveNodes struct {
 	updateSignal       chan struct{}
 }
 
+// GetActiveNodes returns nodes that are currently considered healthy.
+func (aln *AlternatorLiveNodes) GetActiveNodes() []url.URL {
+	// For now these are just plugs for future nodes health implementation
+	return aln.GetNodes()
+}
+
+// GetQuarantinedNodes returns nodes currently marked as unhealthy.
+func (aln *AlternatorLiveNodes) GetQuarantinedNodes() []url.URL {
+	// For now these are just plugs for future nodes health implementation
+	return nil
+}
+
 // ALNConfig a config for `AlternatorLiveNodes`
 type ALNConfig struct {
 	Scheme       string

--- a/shared/query_plan.go
+++ b/shared/query_plan.go
@@ -1,0 +1,66 @@
+package shared
+
+import (
+	"math/rand"
+	"net/url"
+	"time"
+)
+
+type nodesSource interface {
+	GetActiveNodes() []url.URL
+	GetQuarantinedNodes() []url.URL
+}
+
+// LazyQueryPlan lazily materializes a list of nodes to execute a request against.
+// It defers fetching active and quarantined nodes from the source until the first
+// time they are needed by Next().
+type LazyQueryPlan struct {
+	nodes            nodesSource
+	activeNodes      []url.URL
+	quarantinedNodes []url.URL
+	rnd              *rand.Rand
+}
+
+// NewLazyQueryPlan constructs a plan bound to the provided nodes source.
+func NewLazyQueryPlan(nodes nodesSource) *LazyQueryPlan {
+	return &LazyQueryPlan{
+		nodes: nodes,
+		rnd:   rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Next returns the next node to try. It iterates over active nodes first and then
+// quarantined nodes, picking a random node from the remaining pool and removing it
+// so that a node is never returned twice. If no nodes remain, it returns the zero url.URL.
+func (p *LazyQueryPlan) Next() url.URL {
+	if p.activeNodes == nil {
+		p.activeNodes = makeSureNotNil(p.nodes.GetActiveNodes())
+	}
+	if len(p.activeNodes) > 0 {
+		return p.pickAndRemove(&p.activeNodes)
+	}
+
+	if p.quarantinedNodes == nil {
+		p.quarantinedNodes = makeSureNotNil(p.nodes.GetQuarantinedNodes())
+	}
+	if len(p.quarantinedNodes) > 0 {
+		return p.pickAndRemove(&p.quarantinedNodes)
+	}
+
+	return url.URL{}
+}
+
+func (p *LazyQueryPlan) pickAndRemove(nodes *[]url.URL) url.URL {
+	idx := p.rnd.Intn(len(*nodes))
+	node := (*nodes)[idx]
+	(*nodes)[idx] = (*nodes)[len(*nodes)-1]
+	*nodes = (*nodes)[:len(*nodes)-1]
+	return node
+}
+
+func makeSureNotNil(in []url.URL) []url.URL {
+	if in == nil {
+		return []url.URL{}
+	}
+	return in
+}

--- a/shared/query_plan_unit_test.go
+++ b/shared/query_plan_unit_test.go
@@ -1,0 +1,122 @@
+package shared
+
+import (
+	"math/rand"
+	"net/url"
+	"testing"
+)
+
+type fakeNodesSource struct {
+	activeNodes      []url.URL
+	quarantinedNodes []url.URL
+	activeCalls      int
+	quarantinedCalls int
+}
+
+func (f *fakeNodesSource) GetActiveNodes() []url.URL {
+	f.activeCalls++
+	return append([]url.URL(nil), f.activeNodes...)
+}
+
+func (f *fakeNodesSource) GetQuarantinedNodes() []url.URL {
+	f.quarantinedCalls++
+	return append([]url.URL(nil), f.quarantinedNodes...)
+}
+
+func TestLazyQueryPlan(t *testing.T) {
+	t.Run("NextRandomUnique", func(t *testing.T) {
+		active := []url.URL{{Host: "a"}, {Host: "b"}}
+		quarantined := []url.URL{{Host: "c"}}
+		source := &fakeNodesSource{
+			activeNodes:      active,
+			quarantinedNodes: quarantined,
+		}
+
+		plan := NewLazyQueryPlan(source)
+
+		seen := map[string]struct{}{}
+		for i := 0; i < len(active)+len(quarantined); i++ {
+			node := plan.Next()
+			if node.Host == "" {
+				t.Fatalf("expected node on iteration %d", i)
+			}
+			if _, ok := seen[node.Host]; ok {
+				t.Fatalf("node %s returned more than once", node.Host)
+			}
+			seen[node.Host] = struct{}{}
+		}
+
+		if node := plan.Next(); node.Host != "" {
+			t.Fatalf("expected zero value after exhausting nodes, got %v", node)
+		}
+
+		if source.activeCalls != 1 {
+			t.Fatalf("expected active nodes fetched once, got %d", source.activeCalls)
+		}
+		if source.quarantinedCalls != 1 {
+			t.Fatalf("expected quarantined nodes fetched once, got %d", source.quarantinedCalls)
+		}
+	})
+
+	t.Run("OrderDeterministicWithSeed", func(t *testing.T) {
+		active := []url.URL{{Host: "a"}, {Host: "b"}, {Host: "c"}}
+		source := &fakeNodesSource{activeNodes: active}
+
+		plan := NewLazyQueryPlan(source)
+		plan.rnd = rand.New(rand.NewSource(1)) // deterministically shuffle
+
+		got := []string{
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+		}
+
+		want := []string{"c", "b", "a"}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
+			}
+		}
+	})
+
+	t.Run("OnlyQuarantined", func(t *testing.T) {
+		source := &fakeNodesSource{
+			activeNodes:      nil,
+			quarantinedNodes: []url.URL{{Host: "q1"}, {Host: "q2"}},
+		}
+
+		plan := NewLazyQueryPlan(source)
+
+		first := plan.Next()
+		second := plan.Next()
+		if first.Host == "" || second.Host == "" || first.Host == second.Host {
+			t.Fatalf("expected two unique quarantined nodes, got %v and %v", first, second)
+		}
+		if third := plan.Next(); third.Host != "" {
+			t.Fatalf("expected exhaustion after quarantined nodes, got %v", third)
+		}
+
+		if source.activeCalls != 1 {
+			t.Fatalf("expected one call to GetActiveNodes, got %d", source.activeCalls)
+		}
+		if source.quarantinedCalls != 1 {
+			t.Fatalf("expected one call to GetQuarantinedNodes, got %d", source.quarantinedCalls)
+		}
+	})
+
+	t.Run("EmptySource", func(t *testing.T) {
+		source := &fakeNodesSource{}
+		plan := NewLazyQueryPlan(source)
+
+		if node := plan.Next(); node.Host != "" {
+			t.Fatalf("expected zero value from empty source, got %v", node)
+		}
+
+		if source.activeCalls != 1 {
+			t.Fatalf("expected active nodes fetched once, got %d", source.activeCalls)
+		}
+		if source.quarantinedCalls != 1 {
+			t.Fatalf("expected quarantined nodes fetched once, got %d", source.quarantinedCalls)
+		}
+	})
+}

--- a/shared/tests/mocks/round_tripper.go
+++ b/shared/tests/mocks/round_tripper.go
@@ -1,0 +1,46 @@
+// Package mocks provides test doubles used across shared tests.
+package mocks
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// MockRoundTripper is a test transport that returns different responses
+// depending on whether it's an Alternator discovery request, node health request, or DynamoDB API request
+type MockRoundTripper struct {
+	AlternatorRequest func(*http.Request) (*http.Response, error)
+	NodeHealthRequest func(*http.Request) (*http.Response, error)
+	DynamoDBRequest   func(*http.Request) (*http.Response, error)
+}
+
+// RoundTrip dispatches requests to the configured handler based on URL path and method.
+func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	// Distinguish between different request types based on URL path and method
+	if strings.HasPrefix(req.URL.Path, "/localnodes") {
+		// This is an Alternator request to discover nodes
+		if m.AlternatorRequest != nil {
+			return m.AlternatorRequest(req)
+		}
+		return nil, errors.New("AlternatorRequest not configured")
+	}
+
+	if (req.URL.Path == "/" || req.URL.Path == "") && req.Method == "GET" {
+		// This is a node health check request (GET to /)
+		if m.NodeHealthRequest != nil {
+			return m.NodeHealthRequest(req)
+		}
+		return nil, errors.New("NodeHealthRequest not configured")
+	}
+
+	// This is a DynamoDB API request (POST to /)
+	if m.DynamoDBRequest != nil {
+		return m.DynamoDBRequest(req)
+	}
+	return nil, errors.New("DynamoDBRequest not configured")
+}


### PR DESCRIPTION
We need to do the same as CQL does, get cluster nodes and randmly
iterate over them.
For that purpose we need to have an entity that holds all necessary
information between the retries and attach it to the request context.

Fixes: https://github.com/scylladb/alternator-client-golang/issues/34