### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/attach-project-to-issue.yml
+++ b/.github/workflows/attach-project-to-issue.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   add-issue-to-drivers-team:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Add issue ${{ github.event.issue.number }} to Drivers-Team github project
         uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/alternator-client-golang/security/code-scanning/1](https://github.com/scylladb/alternator-client-golang/security/code-scanning/1)

In general, the fix is to explicitly specify a minimal `permissions` block either at the workflow root or at the job level so that the automatically provisioned `GITHUB_TOKEN` does not have unnecessary write access. Since this workflow only needs to respond to issues and pull requests and uses a separate PAT secret for project modification, we can safely restrict `GITHUB_TOKEN` to `permissions: read-all` (or an equivalent minimal set, e.g., just `contents: read`) unless tighter scoping is required.

The best single fix without changing existing functionality is to add a `permissions` block to the `add-issue-to-drivers-team` job (or to the workflow root). To be minimally invasive and clearly linked to the job CodeQL flagged, we will add it under `jobs: add-issue-to-drivers-team:`. A conservative secure baseline is:

```yaml
permissions:
  contents: read
```

This gives `GITHUB_TOKEN` only read access to repository contents, which is typically sufficient for Actions’ default operations and does not interfere with the custom `secrets.GIT_PROJECT_TOKEN` used by `actions/add-to-project`. No new methods, imports, or definitions are required; only the YAML needs updating in `.github/workflows/attach-project-to-issue.yml` around the job definition (lines 9–12).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
