### PR TITLE
Refactor KeyAffinity API to reflect single partition key constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ The driver automatically learns partition key information from your DynamoDB ope
 
 #### Pre-Configuring Partition Keys with WithPkInfo
 
-If your workload consists **only of PutItem operations**, the driver cannot automatically discover partition keys. In this case, use `WithPkInfo` to pre-configure the partition key columns:
-
+If your workload consists **only of PutItem operations**, the driver cannot automatically discover partition key. 
+In this case, use `WithPkInfo` to pre-configure the partition key column name:
 ```go
 h, err := helper.NewHelper(
     []string{"x.x.x.x"},
@@ -224,8 +224,8 @@ h, err := helper.NewHelper(
     helper.WithCredentials("whatever", "secret"),
     helper.WithKeyRouteAffinity(
         helper.NewKeyRouteAffinityConfig(helper.KeyRouteAffinityWrite).
-            WithPkInfo(map[string][]string{
-                "users":  {"userId"},
+            WithPkInfo(map[string]string{
+                "users":  "userId",
             }),
     ),
 )
@@ -235,8 +235,6 @@ h, err := helper.NewHelper(
 - ✅ Your workload is **PutItem-only** and you want routing optimization from the first request
 - ✅ You want to avoid the small overhead of auto-discovery
 - ✅ You know your table schemas upfront and want explicit configuration
-
-**Important**: For composite keys in `WithPkInfo`, the order doesn't matter - the driver will sort them alphabetically internally for consistent hashing.
 
 ### Decrypting TLS
 

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -571,8 +571,8 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				name: "KeyRouteAffinityWrite",
 				optimizeOption: func() Option {
 					return WithKeyRouteAffinity(
-						shared.NewKeyRouteAffinityConfig(KeyRouteAffinityRMW).WithPkInfo(map[string][]string{
-							"test-table": {"id"},
+						shared.NewKeyRouteAffinityConfig(KeyRouteAffinityRMW).WithPkInfo(map[string]string{
+							"test-table": "id",
 						}),
 					)
 				},
@@ -582,8 +582,8 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				name: "KeyRouteAffinityAll",
 				optimizeOption: func() Option {
 					return WithKeyRouteAffinity(
-						shared.NewKeyRouteAffinityConfig(KeyRouteAffinityAnyWrite).WithPkInfo(map[string][]string{
-							"test-table": {"id"},
+						shared.NewKeyRouteAffinityConfig(KeyRouteAffinityAnyWrite).WithPkInfo(map[string]string{
+							"test-table": "id",
 						}),
 					)
 				},
@@ -713,8 +713,8 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
 				WithCredentials("test-key", "test-secret"),
 				WithKeyRouteAffinity(
-					shared.NewKeyRouteAffinityConfig(KeyRouteAffinityAnyWrite).WithPkInfo(map[string][]string{
-						"test-table": {"id"},
+					shared.NewKeyRouteAffinityConfig(KeyRouteAffinityAnyWrite).WithPkInfo(map[string]string{
+						"test-table": "id",
 					}),
 				),
 			)
@@ -790,8 +790,8 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
 				WithCredentials("test-key", "test-secret"),
 				WithKeyRouteAffinity(
-					shared.NewKeyRouteAffinityConfig(KeyRouteAffinityRMW).WithPkInfo(map[string][]string{
-						"test-table": {"id"},
+					shared.NewKeyRouteAffinityConfig(KeyRouteAffinityRMW).WithPkInfo(map[string]string{
+						"test-table": "id",
 					}),
 				),
 			)

--- a/shared/config.go
+++ b/shared/config.go
@@ -63,11 +63,11 @@ type Config struct {
 	RequestCompression RequestCompressionFunc
 	// NodeHealthStoreConfig controls node health tracking logic
 	NodeHealthStoreConfig nodeshealth.NodeHealthStoreConfig
-	// KeyRouteAffinity configures which operations should use routing optimization heuristics
+	// KeyRouteAffinity configures route affinity feature
 	KeyRouteAffinity KeyRouteAffinityConfig
 }
 
-// KeyRouteAffinity specifies the type of operations that should use routing optimization
+// KeyRouteAffinity specifies the type of operations that should use route affinity
 type KeyRouteAffinity int
 
 const (
@@ -92,20 +92,20 @@ const (
 // KeyRouteAffinityConfig holds configuration for routing optimization heuristics
 type KeyRouteAffinityConfig struct {
 	Type           KeyRouteAffinity
-	PkInfoPerTable map[string][]string
+	PkInfoPerTable map[string]string
 }
 
 // NewKeyRouteAffinityConfig creates a new KeyRouteAffinityConfig with initialized map
 func NewKeyRouteAffinityConfig(keyRouteAffinity KeyRouteAffinity) KeyRouteAffinityConfig {
 	return KeyRouteAffinityConfig{
 		Type:           keyRouteAffinity,
-		PkInfoPerTable: make(map[string][]string),
+		PkInfoPerTable: make(map[string]string),
 	}
 }
 
-// WithPkInfo sets the partition key information per table for routing optimization
-func (kr KeyRouteAffinityConfig) WithPkInfo(pkInfo map[string][]string) KeyRouteAffinityConfig {
-	kr.PkInfoPerTable = pkInfo
+// WithPkInfo sets the partition key name per table for route affinity
+func (kr KeyRouteAffinityConfig) WithPkInfo(pkNamePerTable map[string]string) KeyRouteAffinityConfig {
+	kr.PkInfoPerTable = pkNamePerTable
 	return kr
 }
 
@@ -481,8 +481,8 @@ func CloneAWSConfigOptions(options []any) []any {
 	return out
 }
 
-// WithKeyRouteAffinity enables routing optimization heuristics for the specified operation types.
-// Routing optimization benefits from routing to the same coordinator to improve Paxos performance.
+// WithKeyRouteAffinity enables route affinity for the specified operation types.
+// Route affinity makes driver pick same coordinator to improve Paxos performance.
 func WithKeyRouteAffinity(keyRouteAffinityConfig KeyRouteAffinityConfig) Option {
 	return func(config *Config) {
 		config.KeyRouteAffinity = keyRouteAffinityConfig


### PR DESCRIPTION
Updates the KeyAffinity API to enforce that only one partition key is possible per table, 
simplifying the interface and preventing invalid configurations.

This PR does not solve properly autolearning part, it will be addressed in next PR.