### PR TITLE
Introduce new names for KeyAffinity mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ ScyllaDB's Alternator supports different write isolation modes configured via `a
 #### When to Use KeyRouteAffinity
 
 Enable KeyRouteAffinity when:
-- Your Alternator cluster is configured with `alternator_write_isolation: only_rmw_uses_lwt` (use `KeyRouteAffinityWrite`) or `always` (use `KeyRouteAffinityAll`)
+- Your Alternator cluster is configured with `alternator_write_isolation: only_rmw_uses_lwt` (use `KeyRouteAffinityRMW`) or `always` (use `KeyRouteAffinityAnyWrite`)
 - You perform conditional updates/deletes on the same items repeatedly
 - You want to optimize LWT performance by ensuring the same coordinator handles requests for the same partition key
 
@@ -202,8 +202,8 @@ Enable KeyRouteAffinity when:
 There are three KeyRouteAffinity modes:
 
 1. **`KeyRouteAffinityNone`** (default): Disabled. Requests are distributed randomly across nodes.
-2. **`KeyRouteAffinityWrite`**: Enables routing optimization for write operations (PutItem, UpdateItem, DeleteItem).
-3. **`KeyRouteAffinityAll`**: Enables routing optimization for all operations including reads (GetItem).
+2. **`KeyRouteAffinityRMW`**: Enables route affinity for conditional write operations, operations that needs read before write.
+3. **`KeyRouteAffinityAnyWrite`**: Enables routing optimization for all write operations.
 
 #### Automatic Partition Key Discovery
 

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -571,7 +571,7 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				name: "KeyRouteAffinityWrite",
 				optimizeOption: func() Option {
 					return WithKeyRouteAffinity(
-						shared.NewKeyRouteAffinityConfig(shared.KeyRouteAffinityWrite).WithPkInfo(map[string][]string{
+						shared.NewKeyRouteAffinityConfig(KeyRouteAffinityRMW).WithPkInfo(map[string][]string{
 							"test-table": {"id"},
 						}),
 					)
@@ -582,7 +582,7 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				name: "KeyRouteAffinityAll",
 				optimizeOption: func() Option {
 					return WithKeyRouteAffinity(
-						shared.NewKeyRouteAffinityConfig(shared.KeyRouteAffinityAll).WithPkInfo(map[string][]string{
+						shared.NewKeyRouteAffinityConfig(KeyRouteAffinityAnyWrite).WithPkInfo(map[string][]string{
 							"test-table": {"id"},
 						}),
 					)
@@ -713,7 +713,7 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
 				WithCredentials("test-key", "test-secret"),
 				WithKeyRouteAffinity(
-					shared.NewKeyRouteAffinityConfig(shared.KeyRouteAffinityAll).WithPkInfo(map[string][]string{
+					shared.NewKeyRouteAffinityConfig(KeyRouteAffinityAnyWrite).WithPkInfo(map[string][]string{
 						"test-table": {"id"},
 					}),
 				),
@@ -790,7 +790,7 @@ func assertNodesStatus(t *testing.T, nodes AlternatorNodesSource, liveNodes, qua
 				WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
 				WithCredentials("test-key", "test-secret"),
 				WithKeyRouteAffinity(
-					shared.NewKeyRouteAffinityConfig(shared.KeyRouteAffinityWrite).WithPkInfo(map[string][]string{
+					shared.NewKeyRouteAffinityConfig(KeyRouteAffinityRMW).WithPkInfo(map[string][]string{
 						"test-table": {"id"},
 					}),
 				),

--- a/shared/config.go
+++ b/shared/config.go
@@ -71,12 +71,22 @@ type Config struct {
 type KeyRouteAffinity int
 
 const (
-	// KeyRouteAffinityNone disables routing optimization for all operations
-	KeyRouteAffinityNone KeyRouteAffinity = iota
-	// KeyRouteAffinityWrite enables routing optimization for all write operations (Put, Update, Delete)
+	_ KeyRouteAffinity = iota
+	// KeyRouteAffinityWrite enables route affinity for conditional write operations, writes that require read before write
+	// Deprecated: deprecated ude to the confusing name, use KeyRouteAffinityRMW instead
 	KeyRouteAffinityWrite
-	// KeyRouteAffinityAll enables routing optimization for all operations including reads
+	// KeyRouteAffinityAll enables route affinity for all write operations
+	// Deprecated: deprecated ude to the confusing name, use KeyRouteAffinityAnyWrite instead
 	KeyRouteAffinityAll
+)
+
+const (
+	// KeyRouteAffinityNone disables route affinity for all operations
+	KeyRouteAffinityNone KeyRouteAffinity = iota
+	// KeyRouteAffinityRMW enables route affinity for conditional write operations, writes that require read before write
+	KeyRouteAffinityRMW
+	// KeyRouteAffinityAnyWrite enables route affinity for all write operations
+	KeyRouteAffinityAnyWrite
 )
 
 // KeyRouteAffinityConfig holds configuration for routing optimization heuristics


### PR DESCRIPTION
Current names do not reflect what is going on on the backend. The difference is the following:
1. No read operation is scheduled via LWT, even in `always` isolation mode
2. only_rmw_uses_lwt - schedules only conditional writes
3. always - schedule all writes via LWT