### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build lint and run tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/alternator-client-golang/security/code-scanning/2](https://github.com/scylladb/alternator-client-golang/security/code-scanning/2)

In general, the fix is to define an explicit `permissions` block that grants only the scopes the job truly needs. For a test pipeline that checks out code and runs `make` commands without interacting with the GitHub API in a write capacity, the minimal necessary permission is usually `contents: read`.

For this workflow, the safest and least-intrusive fix is to add a `permissions` block at the job level under `jobs.test`, setting `contents: read`. This confines the GITHUB_TOKEN used in this test job to read-only access to repository contents. No changes to steps, commands, or external dependencies are required. Concretely, in `.github/workflows/tests.yml`, under `jobs:`, within the `test:` job, insert:

```yaml
    permissions:
      contents: read
```

between `timeout-minutes: 10` and `steps:` (or adjacent to those keys), preserving indentation (4 spaces under `test:`). No imports or method definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
