### PR TITLE
Add WithMaxIdleHTTPConnectionsPerHost option to control http.Transport.MaxIdleConnsPerHost

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ _, err := ddb.GetItem(ctx, &dynamodb.GetItemInput{TableName: aws.String("tbl"), 
 ```
 SDK v1 users can apply the same pattern with the `*WithContext` methods (e.g., `GetItemWithContext`).
 
+### HTTP connection pool settings
+
+The library maintains a pool of idle HTTP connections to Alternator nodes for reuse, reducing latency and overhead. You can tune connection pooling behavior with the following options:
+
+- **`WithMaxIdleHTTPConnections(value int)`**: Controls the maximum total number of idle connections across all hosts. Default is `100`. Set to `0` to disable connection reuse entirely.
+
+- **`WithMaxIdleHTTPConnectionsPerHost(value int)`**: Controls the maximum number of idle connections per host. Default is `http.DefaultMaxIdleConnsPerHost` which is `2`. Increase this value when making many concurrent requests to the same node.
+
+- **`WithIdleHTTPConnectionTimeout(value time.Duration)`**: Controls how long idle connections remain in the pool before being closed. Default is `6 hours`. Shorter timeouts free resources faster but may increase connection setup overhead.
+
+Example:
+```go
+h, _ := helper.NewHelper(
+    []string{"x.x.x.x"},
+    helper.WithMaxIdleHTTPConnections(200),
+    helper.WithMaxIdleHTTPConnectionsPerHost(10),
+    helper.WithIdleHTTPConnectionTimeout(30*time.Minute),
+)
+```
+
 ## Distinctive features
 
 ### Headers optimization

--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -114,6 +114,9 @@ var (
 	//  increases http and server efficiency and reduces latency
 	WithMaxIdleHTTPConnections = shared.WithMaxIdleHTTPConnections
 
+	// WithMaxIdleHTTPConnectionsPerHost controls maximum number of idle http connections per host held by http.Transport
+	WithMaxIdleHTTPConnectionsPerHost = shared.WithMaxIdleHTTPConnectionsPerHost
+
 	// WithIdleHTTPConnectionTimeout controls timeout for idle http connections held by http.Transport
 	WithIdleHTTPConnectionTimeout = shared.WithIdleHTTPConnectionTimeout
 

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -137,6 +137,10 @@ var (
 	//  increases http and server efficiency and reduces latency
 	WithMaxIdleHTTPConnections = shared.WithMaxIdleHTTPConnections
 
+	// WithMaxIdleHTTPConnectionsPerHost controls maximum number of idle http connections per host held by http.Transport
+	// If zero, http.DefaultMaxIdleConnsPerHost is used.
+	WithMaxIdleHTTPConnectionsPerHost = shared.WithMaxIdleHTTPConnectionsPerHost
+
 	// WithIdleHTTPConnectionTimeout controls timeout for idle http connections held by http.Transport
 	WithIdleHTTPConnectionTimeout = shared.WithIdleHTTPConnectionTimeout
 

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -67,6 +67,8 @@ type ALNConfig struct {
 	// TLS session cache
 	TLSSessionCache        tls.ClientSessionCache
 	MaxIdleHTTPConnections int
+	// Maximum number of idle HTTP connections per host
+	MaxIdleHTTPConnectionsPerHost int
 	// Time to keep idle http connection alive
 	IdleHTTPConnectionTimeout time.Duration
 	// A hook to control http transports
@@ -80,17 +82,18 @@ type ALNConfig struct {
 // NewDefaultALNConfig creates new default ALNConfig
 func NewDefaultALNConfig() ALNConfig {
 	return ALNConfig{
-		Scheme:                    defaultScheme,
-		Port:                      defaultPort,
-		RoutingScope:              rt.NewClusterScope(),
-		UpdatePeriod:              defaultUpdatePeriod,
-		IdleUpdatePeriod:          time.Minute, // Don't update by default
-		TLSSessionCache:           defaultTLSSessionCache,
-		MaxIdleHTTPConnections:    100,
-		IdleHTTPConnectionTimeout: defaultIdleConnectionTimeout,
-		HTTPClientTimeout:         http.DefaultClient.Timeout,
-		Logger:                    logxzap.DefaultLogger(),
-		NodeHealthStoreConfig:     nodeshealth.DefaultNodeHealthStoreConfig(),
+		Scheme:                        defaultScheme,
+		Port:                          defaultPort,
+		RoutingScope:                  rt.NewClusterScope(),
+		UpdatePeriod:                  defaultUpdatePeriod,
+		IdleUpdatePeriod:              time.Minute, // Don't update by default
+		TLSSessionCache:               defaultTLSSessionCache,
+		MaxIdleHTTPConnections:        100,
+		MaxIdleHTTPConnectionsPerHost: http.DefaultMaxIdleConnsPerHost,
+		IdleHTTPConnectionTimeout:     defaultIdleConnectionTimeout,
+		HTTPClientTimeout:             http.DefaultClient.Timeout,
+		Logger:                        logxzap.DefaultLogger(),
+		NodeHealthStoreConfig:         nodeshealth.DefaultNodeHealthStoreConfig(),
 	}
 }
 
@@ -199,6 +202,14 @@ func WithALNTLSSessionCache(cache tls.ClientSessionCache) ALNOption {
 func WithALNMaxIdleHTTPConnections(value int) ALNOption {
 	return func(config *ALNConfig) {
 		config.MaxIdleHTTPConnections = value
+	}
+}
+
+// WithALNMaxIdleHTTPConnectionsPerHost controls maximum number of idle http connections per host held by http.Transport
+// If zero, http.DefaultMaxIdleConnsPerHost is used.
+func WithALNMaxIdleHTTPConnectionsPerHost(value int) ALNOption {
+	return func(config *ALNConfig) {
+		config.MaxIdleHTTPConnectionsPerHost = value
 	}
 }
 

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -27,6 +27,7 @@ func NewALNHTTPTransport(config ALNConfig) http.RoundTripper {
 func PatchHTTPTransport(config ALNConfig, transport *http.Transport) http.RoundTripper {
 	transport.IdleConnTimeout = config.IdleHTTPConnectionTimeout
 	transport.MaxIdleConns = config.MaxIdleHTTPConnections
+	transport.MaxIdleConnsPerHost = config.MaxIdleHTTPConnectionsPerHost
 
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}


### PR DESCRIPTION
### Description
Adds `WithMaxIdleHTTPConnectionsPerHost` option to control `http.Transport.MaxIdleConnsPerHost` for both `sdkv1` and `sdkv2`.

This complements the existing `WithMaxIdleHTTPConnections` option by allowing fine-grained control over connection pooling per host, which is useful when making many concurrent requests to the same Alternator node.

### Changes:
  - Added `MaxIdleHTTPConnectionsPerHost` field to Config and `ALNConfig` structs
  - Added `WithMaxIdleHTTPConnectionsPerHost` option for high-level config
  - Added `WithALNMaxIdleHTTPConnectionsPerHost` option for `ALNConfig`
  - Applied the setting in `PatchHTTPTransport()`
  - Exported the option from both `sdkv1` and `sdkv2` packages
  - Documented HTTP connection pool settings in `README.md`
  - Default value is http.DefaultMaxIdleConnsPerHost (2)

### Usage:
```
  h, _ := helper.NewHelper(
      []string{"x.x.x.x"},
      helper.WithMaxIdleHTTPConnectionsPerHost(10),
  )
```