### PR TITLE
Document WithRoutingScope and deprecate WithRack/WithDatacenter

### DIFF
--- a/shared/config.go
+++ b/shared/config.go
@@ -215,7 +215,7 @@ func WithPort(port int) Option {
 }
 
 // WithRack makes DynamoDB client target only nodes from particular rack
-// Deprecated: use WithRoutingScope(rt.Rackcope("dc1", "rack1", nil)) instead
+// Deprecated: use WithRoutingScope(rt.NewRackScope("dc1", "rack1", nil)) instead
 func WithRack(rack string) Option {
 	return func(config *Config) {
 		if config.Datacenter == "" {
@@ -226,7 +226,7 @@ func WithRack(rack string) Option {
 }
 
 // WithDatacenter makes DynamoDB client target only nodes from particular datacenter
-// Deprecated: use WithRoutingScope(rt.DCScope("dc1", nil)) instead
+// Deprecated: use WithRoutingScope(rt.NewDCScope("dc1", nil)) instead
 func WithDatacenter(dc string) Option {
 	return func(config *Config) {
 		config.Datacenter = dc


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for `WithRoutingScope` in README, explaining the three routing scope types (`ClusterScope`, `DCScope`, `RackScope`) and how to chain them with fallbacks
- Mark `WithRack` and `WithDatacenter` as deprecated with migration guidance
- Fix typos in deprecation comments (`rt.Rackcope` -> `rt.NewRackScope`, `rt.DCScope` -> `rt.NewDCScope`)
