### PR TITLE
Pin GitHub Actions to commit hashes and enforce pinning

### DIFF
--- a/.github/workflows/attach-project-to-issue.yml
+++ b/.github/workflows/attach-project-to-issue.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Add issue ${{ github.event.issue.number }} to Drivers-Team github project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: 'https://github.com/orgs/scylladb/projects/71'
           github-token: ${{ secrets.GIT_PROJECT_TOKEN }}

--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -12,30 +12,30 @@ permissions:
 jobs:
   jira-sync-pr-opened:
     if: github.event.action == 'opened' || github.event.action == 'edited'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-in-review:
     if: github.event.action == 'ready_for_review' || github.event.action == 'review_requested'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-add-label:
     if: github.event.action == 'labeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-remove-label:
     if: github.event.action == 'unlabeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-pr-closed:
     if: github.event.action == 'closed'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout target tag
         if: ${{ inputs.target-tag != '' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.target-tag }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install GoLang
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.work"
           cache-dependency-path: "**/go.sum"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "minimumReleaseAge": "90 days"
+    }
   ]
 }


### PR DESCRIPTION
- Update all action references to use full SHA commit hashes
- Configure Renovate to pin digests and require 90-day minimum age

Fixes: https://scylladb.atlassian.net/browse/DRIVER-574