### PR TITLE
Fix BatchWriteItem route affinity in RMW mode

### DIFF
--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -602,9 +602,9 @@ func (lb *Helper) getPkHash(in middleware.InitializeInput) (int64, error) {
 
 	case *dynamodb.BatchWriteItemInput:
 		switch lb.cfg.KeyRouteAffinity.Type {
-		case KeyRouteAffinityRMW, KeyRouteAffinityAnyWrite:
-			// In the case of multi table batch alternator makes it LWT if any table involved is configured to do so
-			// But here for sake of simplicity we apply session-wide configuration to all requests
+		case KeyRouteAffinityAnyWrite:
+			// In the case of multi table batch alternator makes it LWT if any table involved is configured to do so.
+			// Here we apply session-wide configuration to all requests for simplicity.
 			shouldGetHash = true
 		outer:
 			for table, req := range params.RequestItems {

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -1049,7 +1049,6 @@ func TestOptions(t *testing.T) {
 					)
 				},
 				optimizedOps: []string{
-					"BATCH-WRITE",
 					// UPDATE operations that need read-before-write
 					"UPDATE-WITH-UPDATE-EXPRESSION",
 					"UPDATE-CONDITIONAL",


### PR DESCRIPTION
## Summary

Fix `BatchWriteItem` route affinity selection for `KeyRouteAffinityRMW`.

`BatchWriteItem` is a write-only Alternator operation. ScyllaDB only executes it through LWT when write isolation is `always` / `always_use_lwt` (`LWT_ALWAYS`). In `only_rmw_uses_lwt` mode, it is executed as a normal quorum write, so `KeyRouteAffinityRMW` should not pin it to a partition-key route.

This PR changes `sdkv2` so `BatchWriteItem` uses key route affinity only with `KeyRouteAffinityAnyWrite`, and updates the unit test expectation accordingly.

Fixes #96.

## Test Evidence

- `make test-unit`
- `make check-golangci`
- `make build`

Note: the first local `make check-golangci` attempt failed before analyzing the repository because the existing `bin/golangci-lint` binary had been built with Go 1.24 and could not typecheck files requiring Go 1.26. I rebuilt `golangci-lint v2.1.6` locally with Go 1.26.4 and reran `make check-golangci` successfully.