### PR TITLE
ci: pin github-automation Jira sync workflows to commit with pinned actions

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -12,30 +12,30 @@ permissions:
 jobs:
   jira-sync-pr-opened:
     if: github.event.action == 'opened' || github.event.action == 'edited'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-in-review:
     if: github.event.action == 'ready_for_review' || github.event.action == 'review_requested'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-add-label:
     if: github.event.action == 'labeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-remove-label:
     if: github.event.action == 'unlabeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-pr-closed:
     if: github.event.action == 'closed'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main 2025-05-20
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
## Summary

- Updates `scylladb/github-automation` SHA from `83115dc2` → `47138e9` (main, 2026-06-01) across all 5 Jira sync workflow references
- The new commit (from [scylladb/github-automation#195](https://github.com/scylladb/github-automation/pull/195)) pins `actions/checkout` to a full commit SHA, satisfying the org-level policy that requires all actions to be pinned

## Context

PR #97 had CI failures in `jira-sync-pr-opened / manage_opened_gh_event` with:
> `Error: The action actions/checkout@v4 is not allowed in scylladb/alternator-client-golang because all actions must be pinned to a full-length commit SHA.`

The unpinned `actions/checkout@v4` came from the reusable workflows inside the `scylladb/github-automation` repo. This PR updates the reference to the fixed version.