### PR TITLE
Fix deterministic BatchWriteItem affinity target

### DIFF
--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -31,9 +31,12 @@ package sdkv2
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -605,21 +608,7 @@ func (lb *Helper) getPkHash(in middleware.InitializeInput) (int64, error) {
 		case KeyRouteAffinityAnyWrite:
 			// In the case of multi table batch alternator makes it LWT if any table involved is configured to do so.
 			// Here we apply session-wide configuration to all requests for simplicity.
-			shouldGetHash = true
-		outer:
-			for table, req := range params.RequestItems {
-				tableName = table
-				for _, op := range req {
-					if op.DeleteRequest != nil {
-						partitionKey = op.DeleteRequest.Key
-						break outer
-					}
-					if op.PutRequest != nil {
-						partitionKey = op.PutRequest.Item
-						break outer
-					}
-				}
-			}
+			return lb.hashBatchWritePartitionKey(params.RequestItems)
 		default:
 			shouldGetHash = false
 		}
@@ -632,6 +621,220 @@ func (lb *Helper) getPkHash(in middleware.InitializeInput) (int64, error) {
 	}
 
 	return 0, fmt.Errorf("could not get a proper hash")
+}
+
+type batchWriteRoutingTarget struct {
+	tableName           string
+	values              map[string]types.AttributeValue
+	operation           string
+	canonicalAttributes string
+}
+
+func (lb *Helper) hashBatchWritePartitionKey(requestItems map[string][]types.WriteRequest) (int64, error) {
+	targets := selectBatchWriteRoutingTargets(requestItems)
+	if len(targets) == 0 {
+		return 0, fmt.Errorf("batch write request does not have a routing target")
+	}
+
+	for _, target := range targets {
+		keyName := lb.keyAffinity.GetPartitionKeyName(target.tableName)
+		if keyName == "" {
+			lb.triggerUpdateTablePKInformation(target.tableName)
+			return 0, fmt.Errorf("partition key information not found for table %s", target.tableName)
+		}
+
+		val, ok := target.values[keyName]
+		if !ok {
+			continue
+		}
+
+		hash, err := HashAttributeValue(val)
+		if err != nil {
+			continue
+		}
+
+		return hash, nil
+	}
+
+	return 0, fmt.Errorf("batch write request does not have a usable partition key value")
+}
+
+func selectBatchWriteRoutingTargets(requestItems map[string][]types.WriteRequest) []batchWriteRoutingTarget {
+	if len(requestItems) == 0 {
+		return nil
+	}
+
+	targets := make([]batchWriteRoutingTarget, 0)
+	for tableName, writes := range requestItems {
+		for _, write := range writes {
+			if write.PutRequest != nil {
+				targets = append(targets, batchWriteRoutingTarget{
+					tableName:           tableName,
+					values:              write.PutRequest.Item,
+					operation:           "PutRequest",
+					canonicalAttributes: canonicalAttributeValues(write.PutRequest.Item),
+				})
+			}
+			if write.DeleteRequest != nil {
+				targets = append(targets, batchWriteRoutingTarget{
+					tableName:           tableName,
+					values:              write.DeleteRequest.Key,
+					operation:           "DeleteRequest",
+					canonicalAttributes: canonicalAttributeValues(write.DeleteRequest.Key),
+				})
+			}
+		}
+	}
+
+	if len(targets) == 0 {
+		return nil
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].tableName != targets[j].tableName {
+			return targets[i].tableName < targets[j].tableName
+		}
+		if targets[i].canonicalAttributes != targets[j].canonicalAttributes {
+			return targets[i].canonicalAttributes < targets[j].canonicalAttributes
+		}
+		return targets[i].operation < targets[j].operation
+	})
+
+	return targets
+}
+
+func canonicalAttributeValues(values map[string]types.AttributeValue) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	builder.WriteByte('{')
+	for i, key := range keys {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		writeJSONString(&builder, key)
+		builder.WriteByte(':')
+		writeCanonicalAttributeValue(&builder, values[key])
+	}
+	builder.WriteByte('}')
+	return builder.String()
+}
+
+func writeCanonicalAttributeValue(builder *strings.Builder, value types.AttributeValue) {
+	switch value := value.(type) {
+	case *types.AttributeValueMemberS:
+		writeTaggedJSONString(builder, "S", value.Value)
+	case *types.AttributeValueMemberN:
+		writeTaggedJSONString(builder, "N", value.Value)
+	case *types.AttributeValueMemberB:
+		builder.WriteString(`{"B":{"__bytes__":"`)
+		builder.WriteString(hex.EncodeToString(value.Value))
+		builder.WriteString(`"}}`)
+	case *types.AttributeValueMemberBOOL:
+		builder.WriteString(`{"BOOL":`)
+		writeJSONBool(builder, value.Value)
+		builder.WriteByte('}')
+	case *types.AttributeValueMemberNULL:
+		builder.WriteString(`{"NULL":`)
+		writeJSONBool(builder, value.Value)
+		builder.WriteByte('}')
+	case *types.AttributeValueMemberSS:
+		writeTaggedJSONStringList(builder, "SS", value.Value)
+	case *types.AttributeValueMemberNS:
+		writeTaggedJSONStringList(builder, "NS", value.Value)
+	case *types.AttributeValueMemberBS:
+		builder.WriteString(`{"BS":[`)
+		for i, bytes := range value.Value {
+			if i > 0 {
+				builder.WriteByte(',')
+			}
+			builder.WriteString(`{"__bytes__":"`)
+			builder.WriteString(hex.EncodeToString(bytes))
+			builder.WriteString(`"}`)
+		}
+		builder.WriteString(`]}`)
+	case *types.AttributeValueMemberL:
+		builder.WriteString(`{"L":[`)
+		for i, item := range value.Value {
+			if i > 0 {
+				builder.WriteByte(',')
+			}
+			writeCanonicalAttributeValue(builder, item)
+		}
+		builder.WriteString(`]}`)
+	case *types.AttributeValueMemberM:
+		builder.WriteString(`{"M":`)
+		builder.WriteString(canonicalAttributeValues(value.Value))
+		builder.WriteByte('}')
+	default:
+		builder.WriteString(`{"UNKNOWN":true}`)
+	}
+}
+
+func writeTaggedJSONString(builder *strings.Builder, tag, value string) {
+	builder.WriteString(`{"`)
+	builder.WriteString(tag)
+	builder.WriteString(`":`)
+	writeJSONString(builder, value)
+	builder.WriteByte('}')
+}
+
+func writeTaggedJSONStringList(builder *strings.Builder, tag string, values []string) {
+	builder.WriteString(`{"`)
+	builder.WriteString(tag)
+	builder.WriteString(`":[`)
+	for i, value := range values {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		writeJSONString(builder, value)
+	}
+	builder.WriteString(`]}`)
+}
+
+func writeJSONBool(builder *strings.Builder, value bool) {
+	if value {
+		builder.WriteString("true")
+		return
+	}
+	builder.WriteString("false")
+}
+
+func writeJSONString(builder *strings.Builder, value string) {
+	builder.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '"':
+			builder.WriteString(`\"`)
+		case '\\':
+			builder.WriteString(`\\`)
+		case '\b':
+			builder.WriteString(`\b`)
+		case '\f':
+			builder.WriteString(`\f`)
+		case '\n':
+			builder.WriteString(`\n`)
+		case '\r':
+			builder.WriteString(`\r`)
+		case '\t':
+			builder.WriteString(`\t`)
+		default:
+			if r <= 0x1f {
+				_, _ = fmt.Fprintf(builder, `\u%04x`, r)
+			} else {
+				builder.WriteRune(r)
+			}
+		}
+	}
+	builder.WriteByte('"')
 }
 
 type keyAffinity struct {

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -2,6 +2,7 @@ package sdkv2
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -19,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go/middleware"
 	"github.com/klauspost/compress/gzip"
 
 	"github.com/scylladb/alternator-client-golang/shared"
@@ -1251,6 +1254,407 @@ func TestOptions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestBatchWriteItemKeyRouteAffinityDeterministicHashForReorderedWrites(t *testing.T) {
+	t.Parallel()
+
+	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
+	first := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: keyWithID("z-route"),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID("a-route"),
+					},
+				},
+			},
+		},
+	}
+	second := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID("a-route"),
+					},
+				},
+				{
+					PutRequest: &types.PutRequest{
+						Item: keyWithID("z-route"),
+					},
+				},
+			},
+		},
+	}
+
+	firstHash := mustBatchWriteHash(t, h, first)
+	secondHash := mustBatchWriteHash(t, h, second)
+	expectedHash, err := HashAttributeValue(&types.AttributeValueMemberS{Value: "a-route"})
+	if err != nil {
+		t.Fatalf("HashAttributeValue returned error: %v", err)
+	}
+
+	if firstHash != expectedHash {
+		t.Fatalf("expected first request to use hash %d, got %d", expectedHash, firstHash)
+	}
+	if secondHash != expectedHash {
+		t.Fatalf("expected second request to use hash %d, got %d", expectedHash, secondHash)
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityDeterministicHashForTableOrder(t *testing.T) {
+	t.Parallel()
+
+	h := newBatchWriteAffinityTestHelper(map[string]string{
+		"audit":  "id",
+		"orders": "id",
+	})
+	input := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID("orders-key"),
+					},
+				},
+			},
+			"audit": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID("audit-key"),
+					},
+				},
+			},
+		},
+	}
+
+	expectedHash, err := HashAttributeValue(&types.AttributeValueMemberS{Value: "audit-key"})
+	if err != nil {
+		t.Fatalf("HashAttributeValue returned error: %v", err)
+	}
+
+	for i := 0; i < 50; i++ {
+		if hash := mustBatchWriteHash(t, h, input); hash != expectedHash {
+			t.Fatalf("iteration %d: expected hash %d, got %d", i, expectedHash, hash)
+		}
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityCrossLanguageVectors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		input         *dynamodb.BatchWriteItemInput
+		pkInfo        map[string]string
+		tableName     string
+		operation     string
+		pkLabel       string
+		canonical     string
+		hashSigned    int64
+		hashUnsigned  uint64
+		firstSixNodes []string
+	}{
+		{
+			name: "same_table_write_order",
+			input: &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					"orders": {
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberS{Value: "order456"},
+								},
+							},
+						},
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberS{Value: "order123"},
+								},
+							},
+						},
+					},
+				},
+			},
+			pkInfo:        map[string]string{"orders": "pk"},
+			tableName:     "orders",
+			operation:     "PutRequest",
+			pkLabel:       "S:order123",
+			canonical:     `{"pk":{"S":"order123"}}`,
+			hashSigned:    -2126891002421145093,
+			hashUnsigned:  16319853071288406523,
+			firstSixNodes: []string{"node9", "node2", "node10", "node8", "node7", "node5"},
+		},
+		{
+			name: "multi_table_order",
+			input: &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					"sessions": {
+						{
+							DeleteRequest: &types.DeleteRequest{
+								Key: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberS{Value: "session123"},
+								},
+							},
+						},
+					},
+					"orders": {
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"data": &types.AttributeValueMemberS{Value: "value"},
+									"pk":   &types.AttributeValueMemberS{Value: "order456"},
+								},
+							},
+						},
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk":   &types.AttributeValueMemberS{Value: "order123"},
+									"data": &types.AttributeValueMemberS{Value: "value"},
+								},
+							},
+						},
+					},
+				},
+			},
+			pkInfo:        map[string]string{"orders": "pk", "sessions": "pk"},
+			tableName:     "orders",
+			operation:     "PutRequest",
+			pkLabel:       "S:order123",
+			canonical:     `{"data":{"S":"value"},"pk":{"S":"order123"}}`,
+			hashSigned:    -2126891002421145093,
+			hashUnsigned:  16319853071288406523,
+			firstSixNodes: []string{"node9", "node2", "node10", "node8", "node7", "node5"},
+		},
+		{
+			name: "delete_put_same_attributes",
+			input: &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					"orders": {
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberS{Value: "same"},
+								},
+							},
+						},
+						{
+							DeleteRequest: &types.DeleteRequest{
+								Key: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberS{Value: "same"},
+								},
+							},
+						},
+					},
+				},
+			},
+			pkInfo:        map[string]string{"orders": "pk"},
+			tableName:     "orders",
+			operation:     "DeleteRequest",
+			pkLabel:       "S:same",
+			canonical:     `{"pk":{"S":"same"}}`,
+			hashSigned:    -4879317772220196571,
+			hashUnsigned:  13567426301489355045,
+			firstSixNodes: []string{"node1", "node3", "node10", "node7", "node4", "node5"},
+		},
+		{
+			name: "number_partition_key",
+			input: &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					"accounts": {
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberN{Value: "7"},
+								},
+							},
+						},
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberN{Value: "42"},
+								},
+							},
+						},
+					},
+				},
+			},
+			pkInfo:        map[string]string{"accounts": "pk"},
+			tableName:     "accounts",
+			operation:     "PutRequest",
+			pkLabel:       "N:42",
+			canonical:     `{"pk":{"N":"42"}}`,
+			hashSigned:    -5061732451827723051,
+			hashUnsigned:  13385011621881828565,
+			firstSixNodes: []string{"node3", "node7", "node1", "node10", "node2", "node5"},
+		},
+		{
+			name: "binary_partition_key",
+			input: &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					"blobs": {
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberB{Value: []byte{0x01, 0x02, 0x03}},
+								},
+							},
+						},
+						{
+							DeleteRequest: &types.DeleteRequest{
+								Key: map[string]types.AttributeValue{
+									"pk": &types.AttributeValueMemberB{Value: []byte{0x00, 0xff}},
+								},
+							},
+						},
+					},
+				},
+			},
+			pkInfo:        map[string]string{"blobs": "pk"},
+			tableName:     "blobs",
+			operation:     "DeleteRequest",
+			pkLabel:       "B:00ff",
+			canonical:     `{"pk":{"B":{"__bytes__":"00ff"}}}`,
+			hashSigned:    -4376945693382523102,
+			hashUnsigned:  14069798380327028514,
+			firstSixNodes: []string{"node7", "node2", "node5", "node1", "node6", "node9"},
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			targets := selectBatchWriteRoutingTargets(tt.input.RequestItems)
+			if len(targets) == 0 {
+				t.Fatal("expected at least one batch write routing target")
+			}
+
+			target := targets[0]
+			if target.tableName != tt.tableName {
+				t.Fatalf("expected table %q, got %q", tt.tableName, target.tableName)
+			}
+			if target.operation != tt.operation {
+				t.Fatalf("expected operation %q, got %q", tt.operation, target.operation)
+			}
+			if target.canonicalAttributes != tt.canonical {
+				t.Fatalf("expected canonical attributes %s, got %s", tt.canonical, target.canonicalAttributes)
+			}
+
+			pkName := tt.pkInfo[target.tableName]
+			pkValue, ok := target.values[pkName]
+			if !ok {
+				t.Fatalf("target does not contain partition key %q", pkName)
+			}
+			if label := batchWriteAttributeLabel(pkValue); label != tt.pkLabel {
+				t.Fatalf("expected pk %q, got %q", tt.pkLabel, label)
+			}
+
+			hash := mustBatchWriteHash(t, newBatchWriteAffinityTestHelper(tt.pkInfo), tt.input)
+			if hash != tt.hashSigned {
+				t.Fatalf("expected signed hash %d, got %d", tt.hashSigned, hash)
+			}
+			if unsigned := uint64(hash); unsigned != tt.hashUnsigned {
+				t.Fatalf("expected unsigned hash %d, got %d", tt.hashUnsigned, unsigned)
+			}
+
+			if diff := cmp.Diff(tt.firstSixNodes, batchWriteAffinityNodeSequence(hash, 6)); diff != "" {
+				t.Fatalf("unexpected node sequence (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func newBatchWriteAffinityTestHelper(pkInfo map[string]string) *Helper {
+	cfg := shared.NewDefaultConfig()
+	cfg.KeyRouteAffinity = shared.NewKeyRouteAffinityConfig(shared.KeyRouteAffinityAnyWrite).WithPkInfo(pkInfo)
+
+	return &Helper{
+		cfg: *cfg,
+		keyAffinity: keyAffinity{
+			pkInfoPerTable: pkInfo,
+		},
+	}
+}
+
+func mustBatchWriteHash(t *testing.T, h *Helper, input *dynamodb.BatchWriteItemInput) int64 {
+	t.Helper()
+
+	hash, err := h.getPkHash(middleware.InitializeInput{Parameters: input})
+	if err != nil {
+		t.Fatalf("getPkHash returned error: %v", err)
+	}
+	return hash
+}
+
+func batchWriteAttributeLabel(value types.AttributeValue) string {
+	switch value := value.(type) {
+	case *types.AttributeValueMemberS:
+		return "S:" + value.Value
+	case *types.AttributeValueMemberN:
+		return "N:" + value.Value
+	case *types.AttributeValueMemberB:
+		return "B:" + hex.EncodeToString(value.Value)
+	default:
+		return fmt.Sprintf("%T", value)
+	}
+}
+
+type batchWriteAffinityNodeSource struct {
+	activeNodes []url.URL
+}
+
+func (s batchWriteAffinityNodeSource) GetActiveNodes() []url.URL {
+	return append([]url.URL(nil), s.activeNodes...)
+}
+
+func (s batchWriteAffinityNodeSource) GetQuarantinedNodes() []url.URL {
+	return nil
+}
+
+func batchWriteAffinityNodeSequence(seed int64, count int) []string {
+	source := batchWriteAffinityNodeSource{
+		activeNodes: make([]url.URL, 0, 10),
+	}
+	for i := 1; i <= 10; i++ {
+		source.activeNodes = append(source.activeNodes, url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("node%d.example.com:8000", i),
+		})
+	}
+
+	plan := shared.NewLazyQueryPlanWithSeed(source, seed)
+	nodes := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		node := plan.Next()
+		if node.Host == "" {
+			break
+		}
+		host, _, _ := strings.Cut(node.Hostname(), ".")
+		nodes = append(nodes, host)
+	}
+	return nodes
+}
+
+func itemWithID(value string) map[string]types.AttributeValue {
+	item := keyWithID(value)
+	item["data"] = &types.AttributeValueMemberS{Value: "payload"}
+	return item
+}
+
+func keyWithID(value string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"id": &types.AttributeValueMemberS{Value: value},
+	}
 }
 
 func sortNodes(nodes []url.URL) []url.URL {


### PR DESCRIPTION
## Summary

- Align SDK v2 `BatchWriteItem` key-affinity target selection with the cross-language algorithm from #101.
- Sort all valid BatchWrite candidates by `(table_name, canonical_json(attributes), operation)`.
- Canonicalize AttributeValue maps with sorted object keys, no insignificant whitespace, preserved UTF-8 strings, and hex-wrapped binary values.
- Try sorted BatchWrite candidates until a usable partition-key value is found, instead of depending on Go map iteration or write slice order.
- Add executable cross-language vectors covering the selected target, signed/unsigned hash, and first six seeded query-plan nodes.

Fixes #99
Refs #101

## Cross-language BatchWriteItem selection

For `BatchWriteItem` under `KeyRouteAffinityAnyWrite`, this PR builds candidates from every valid `PutRequest.Item` and `DeleteRequest.Key`, then sorts them by:

```text
(table_name, canonical_json(attributes), operation)
```

The first sorted candidate with known table PK metadata, a present PK attribute, and a supported PK type (`S`, `N`, or `B`) is hashed with the existing cross-language AttributeValue hasher. If no candidate is usable, the request falls back to normal non-affinity routing.

## Cross-language vectors

Using nodes `node1.example.com` through `node10.example.com`, the first 6 affinity-plan nodes are:

| Case | Selected table | Operation | PK | Canonical attributes | Hash signed int64 | Hash u64 | First 6 nodes |
|---|---|---|---|---|---:|---:|---|
| same_table_write_order | orders | PutRequest | S:order123 | `{"pk":{"S":"order123"}}` | -2126891002421145093 | 16319853071288406523 | node9,node2,node10,node8,node7,node5 |
| multi_table_order | orders | PutRequest | S:order123 | `{"data":{"S":"value"},"pk":{"S":"order123"}}` | -2126891002421145093 | 16319853071288406523 | node9,node2,node10,node8,node7,node5 |
| delete_put_same_attributes | orders | DeleteRequest | S:same | `{"pk":{"S":"same"}}` | -4879317772220196571 | 13567426301489355045 | node1,node3,node10,node7,node4,node5 |
| number_partition_key | accounts | PutRequest | N:42 | `{"pk":{"N":"42"}}` | -5061732451827723051 | 13385011621881828565 | node3,node7,node1,node10,node2,node5 |
| binary_partition_key | blobs | DeleteRequest | B:00ff | `{"pk":{"B":{"__bytes__":"00ff"}}}` | -4376945693382523102 | 14069798380327028514 | node7,node2,node5,node1,node6,node9 |

## Testing

- `go test ./sdkv2 -run 'TestBatchWriteItemKeyRouteAffinity'`
- `go test ./sdkv2`
- `go test ./shared`
- `make -C sdkv2 test-unit`
- `make test-unit`
- `make check-golangci`
- `make build`