### PR TITLE
Implement BatchWrite affinity voting

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -12,30 +12,30 @@ permissions:
 jobs:
   jira-sync-pr-opened:
     if: github.event.action == 'opened' || github.event.action == 'edited'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-in-review:
     if: github.event.action == 'ready_for_review' || github.event.action == 'review_requested'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-add-label:
     if: github.event.action == 'labeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-remove-label:
     if: github.event.action == 'unlabeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-pr-closed:
     if: github.event.action == 'closed'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main 2026-06-01
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/go.work.sum
+++ b/go.work.sum
@@ -4,4 +4,13 @@ github.com/aws/aws-sdk-go-v2/service/signin v1.0.7/go.mod h1:idzZ7gmDeqeNrSPkdbt
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.12/go.mod h1:fEWYKTRGoZNl8tZ77i61/ccwOMJdGxwOhWCkp6TXAr0=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.16/go.mod h1:Jic/xv0Rq/pFNCh3WwpH4BEqdbSAl+IyHro8LbibHD8=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.8/go.mod h1:Xgx+PR1NUOjNmQY+tRMnouRp83JRM8pRMw/vCaVhPkI=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -31,12 +31,9 @@ package sdkv2
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
-	"sort"
-	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -455,8 +452,8 @@ func (lb *Helper) queryPlanAPIOption() func(*middleware.Stack) error {
 							qp = shared.NewLazyQueryPlanWithSeed(lb.nodes, lb.queryPlanSeed)
 						}
 					} else {
-						if pkHash, err := lb.getPkHash(in); err == nil {
-							qp = shared.NewLazyQueryPlanWithSeed(lb.nodes, pkHash)
+						if affinityPlan, err := lb.getAffinityQueryPlan(in); err == nil {
+							qp = affinityPlan
 						} else {
 							qp = shared.NewLazyQueryPlan(lb.nodes)
 						}
@@ -509,7 +506,7 @@ func (lb *Helper) queryPlanAPIOption() func(*middleware.Stack) error {
 }
 
 func (lb *Helper) triggerUpdateTablePKInformation(tableName string) {
-	lb.keyAffinity.TriggerUpdateTablePKInformation(func() (string, string) {
+	lb.keyAffinity.TriggerUpdateTablePKInformation(tableName, func() (string, string) {
 		ddb, err := lb.NewDynamoDB()
 		if err != nil {
 			lb.cfg.Logger.Error("pk-info-updater: failed to create DynamoDB client", logx.Error(err))
@@ -562,6 +559,20 @@ func (lb *Helper) hashPartitionKey(values map[string]types.AttributeValue, table
 	return hash, nil
 }
 
+func (lb *Helper) getAffinityQueryPlan(in middleware.InitializeInput) (*shared.LazyQueryPlan, error) {
+	if params, ok := in.Parameters.(*dynamodb.BatchWriteItemInput); ok {
+		if lb.cfg.KeyRouteAffinity.Type == KeyRouteAffinityAnyWrite {
+			return lb.batchWriteQueryPlan(params.RequestItems)
+		}
+	}
+
+	pkHash, err := lb.getPkHash(in)
+	if err != nil {
+		return nil, err
+	}
+	return shared.NewLazyQueryPlanWithSortedSeed(lb.nodes, pkHash), nil
+}
+
 func (lb *Helper) getPkHash(in middleware.InitializeInput) (int64, error) {
 	shouldGetHash := false
 	var tableName string
@@ -603,15 +614,6 @@ func (lb *Helper) getPkHash(in middleware.InitializeInput) (int64, error) {
 		tableName = aws.ToString(params.TableName)
 		partitionKey = params.Key
 
-	case *dynamodb.BatchWriteItemInput:
-		switch lb.cfg.KeyRouteAffinity.Type {
-		case KeyRouteAffinityAnyWrite:
-			// In the case of multi table batch alternator makes it LWT if any table involved is configured to do so.
-			// Here we apply session-wide configuration to all requests for simplicity.
-			return lb.hashBatchWritePartitionKey(params.RequestItems)
-		default:
-			shouldGetHash = false
-		}
 	}
 
 	if shouldGetHash && tableName != "" {
@@ -623,28 +625,39 @@ func (lb *Helper) getPkHash(in middleware.InitializeInput) (int64, error) {
 	return 0, fmt.Errorf("could not get a proper hash")
 }
 
-type batchWriteRoutingTarget struct {
-	tableName           string
-	values              map[string]types.AttributeValue
-	operation           string
-	canonicalAttributes string
+type batchWriteRoutingCandidate struct {
+	tableName string
+	values    map[string]types.AttributeValue
 }
 
-func (lb *Helper) hashBatchWritePartitionKey(requestItems map[string][]types.WriteRequest) (int64, error) {
-	targets := selectBatchWriteRoutingTargets(requestItems)
-	if len(targets) == 0 {
-		return 0, fmt.Errorf("batch write request does not have a routing target")
+func (lb *Helper) batchWriteQueryPlan(requestItems map[string][]types.WriteRequest) (*shared.LazyQueryPlan, error) {
+	candidates := selectBatchWriteRoutingCandidates(requestItems)
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("batch write request does not have a routing target")
 	}
 
-	for _, target := range targets {
-		keyName := lb.keyAffinity.GetPartitionKeyName(target.tableName)
+	activeNodes := lb.nodes.GetActiveNodes()
+	if len(activeNodes) == 0 {
+		return nil, fmt.Errorf("batch write request does not have active nodes")
+	}
+
+	votes := make(map[url.URL]int)
+	discoveryTriggered := make(map[string]struct{})
+	for _, candidate := range candidates {
+		keyName := lb.keyAffinity.GetPartitionKeyName(candidate.tableName)
 		if keyName == "" {
-			lb.triggerUpdateTablePKInformation(target.tableName)
-			return 0, fmt.Errorf("partition key information not found for table %s", target.tableName)
+			if _, ok := discoveryTriggered[candidate.tableName]; !ok {
+				lb.triggerUpdateTablePKInformation(candidate.tableName)
+				discoveryTriggered[candidate.tableName] = struct{}{}
+			}
+			continue
 		}
 
-		val, ok := target.values[keyName]
+		val, ok := candidate.values[keyName]
 		if !ok {
+			continue
+		}
+		if val == nil {
 			continue
 		}
 
@@ -653,188 +666,65 @@ func (lb *Helper) hashBatchWritePartitionKey(requestItems map[string][]types.Wri
 			continue
 		}
 
-		return hash, nil
+		node := shared.FirstNodeWithSeed(activeNodes, hash)
+		if node.Host != "" {
+			votes[node]++
+		}
 	}
 
-	return 0, fmt.Errorf("batch write request does not have a usable partition key value")
+	preferredNode, ok := selectBatchWritePreferredNode(votes)
+	if !ok {
+		return nil, fmt.Errorf("batch write request does not have a unique preferred node")
+	}
+
+	return shared.NewLazyQueryPlanWithPreferredNode(lb.nodes, preferredNode), nil
 }
 
-func selectBatchWriteRoutingTargets(requestItems map[string][]types.WriteRequest) []batchWriteRoutingTarget {
+func selectBatchWriteRoutingCandidates(requestItems map[string][]types.WriteRequest) []batchWriteRoutingCandidate {
 	if len(requestItems) == 0 {
 		return nil
 	}
 
-	targets := make([]batchWriteRoutingTarget, 0)
+	candidates := make([]batchWriteRoutingCandidate, 0)
 	for tableName, writes := range requestItems {
 		for _, write := range writes {
-			if write.PutRequest != nil {
-				targets = append(targets, batchWriteRoutingTarget{
-					tableName:           tableName,
-					values:              write.PutRequest.Item,
-					operation:           "PutRequest",
-					canonicalAttributes: canonicalAttributeValues(write.PutRequest.Item),
+			switch {
+			case write.PutRequest != nil && write.DeleteRequest == nil && len(write.PutRequest.Item) > 0:
+				candidates = append(candidates, batchWriteRoutingCandidate{
+					tableName: tableName,
+					values:    write.PutRequest.Item,
 				})
-			}
-			if write.DeleteRequest != nil {
-				targets = append(targets, batchWriteRoutingTarget{
-					tableName:           tableName,
-					values:              write.DeleteRequest.Key,
-					operation:           "DeleteRequest",
-					canonicalAttributes: canonicalAttributeValues(write.DeleteRequest.Key),
+			case write.DeleteRequest != nil && write.PutRequest == nil && len(write.DeleteRequest.Key) > 0:
+				candidates = append(candidates, batchWriteRoutingCandidate{
+					tableName: tableName,
+					values:    write.DeleteRequest.Key,
 				})
 			}
 		}
 	}
 
-	if len(targets) == 0 {
-		return nil
-	}
-
-	sort.Slice(targets, func(i, j int) bool {
-		if targets[i].tableName != targets[j].tableName {
-			return targets[i].tableName < targets[j].tableName
-		}
-		if targets[i].canonicalAttributes != targets[j].canonicalAttributes {
-			return targets[i].canonicalAttributes < targets[j].canonicalAttributes
-		}
-		return targets[i].operation < targets[j].operation
-	})
-
-	return targets
+	return candidates
 }
 
-func canonicalAttributeValues(values map[string]types.AttributeValue) string {
-	if len(values) == 0 {
-		return "{}"
-	}
-
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	var builder strings.Builder
-	builder.WriteByte('{')
-	for i, key := range keys {
-		if i > 0 {
-			builder.WriteByte(',')
-		}
-		writeJSONString(&builder, key)
-		builder.WriteByte(':')
-		writeCanonicalAttributeValue(&builder, values[key])
-	}
-	builder.WriteByte('}')
-	return builder.String()
-}
-
-func writeCanonicalAttributeValue(builder *strings.Builder, value types.AttributeValue) {
-	switch value := value.(type) {
-	case *types.AttributeValueMemberS:
-		writeTaggedJSONString(builder, "S", value.Value)
-	case *types.AttributeValueMemberN:
-		writeTaggedJSONString(builder, "N", value.Value)
-	case *types.AttributeValueMemberB:
-		builder.WriteString(`{"B":{"__bytes__":"`)
-		builder.WriteString(hex.EncodeToString(value.Value))
-		builder.WriteString(`"}}`)
-	case *types.AttributeValueMemberBOOL:
-		builder.WriteString(`{"BOOL":`)
-		writeJSONBool(builder, value.Value)
-		builder.WriteByte('}')
-	case *types.AttributeValueMemberNULL:
-		builder.WriteString(`{"NULL":`)
-		writeJSONBool(builder, value.Value)
-		builder.WriteByte('}')
-	case *types.AttributeValueMemberSS:
-		writeTaggedJSONStringList(builder, "SS", value.Value)
-	case *types.AttributeValueMemberNS:
-		writeTaggedJSONStringList(builder, "NS", value.Value)
-	case *types.AttributeValueMemberBS:
-		builder.WriteString(`{"BS":[`)
-		for i, bytes := range value.Value {
-			if i > 0 {
-				builder.WriteByte(',')
-			}
-			builder.WriteString(`{"__bytes__":"`)
-			builder.WriteString(hex.EncodeToString(bytes))
-			builder.WriteString(`"}`)
-		}
-		builder.WriteString(`]}`)
-	case *types.AttributeValueMemberL:
-		builder.WriteString(`{"L":[`)
-		for i, item := range value.Value {
-			if i > 0 {
-				builder.WriteByte(',')
-			}
-			writeCanonicalAttributeValue(builder, item)
-		}
-		builder.WriteString(`]}`)
-	case *types.AttributeValueMemberM:
-		builder.WriteString(`{"M":`)
-		builder.WriteString(canonicalAttributeValues(value.Value))
-		builder.WriteByte('}')
-	default:
-		builder.WriteString(`{"UNKNOWN":true}`)
-	}
-}
-
-func writeTaggedJSONString(builder *strings.Builder, tag, value string) {
-	builder.WriteString(`{"`)
-	builder.WriteString(tag)
-	builder.WriteString(`":`)
-	writeJSONString(builder, value)
-	builder.WriteByte('}')
-}
-
-func writeTaggedJSONStringList(builder *strings.Builder, tag string, values []string) {
-	builder.WriteString(`{"`)
-	builder.WriteString(tag)
-	builder.WriteString(`":[`)
-	for i, value := range values {
-		if i > 0 {
-			builder.WriteByte(',')
-		}
-		writeJSONString(builder, value)
-	}
-	builder.WriteString(`]}`)
-}
-
-func writeJSONBool(builder *strings.Builder, value bool) {
-	if value {
-		builder.WriteString("true")
-		return
-	}
-	builder.WriteString("false")
-}
-
-func writeJSONString(builder *strings.Builder, value string) {
-	builder.WriteByte('"')
-	for _, r := range value {
-		switch r {
-		case '"':
-			builder.WriteString(`\"`)
-		case '\\':
-			builder.WriteString(`\\`)
-		case '\b':
-			builder.WriteString(`\b`)
-		case '\f':
-			builder.WriteString(`\f`)
-		case '\n':
-			builder.WriteString(`\n`)
-		case '\r':
-			builder.WriteString(`\r`)
-		case '\t':
-			builder.WriteString(`\t`)
-		default:
-			if r <= 0x1f {
-				_, _ = fmt.Fprintf(builder, `\u%04x`, r)
-			} else {
-				builder.WriteRune(r)
-			}
+func selectBatchWritePreferredNode(votes map[url.URL]int) (url.URL, bool) {
+	var preferredNode url.URL
+	var preferredVotes int
+	var tied bool
+	for node, count := range votes {
+		switch {
+		case count > preferredVotes:
+			preferredNode = node
+			preferredVotes = count
+			tied = false
+		case count == preferredVotes:
+			tied = true
 		}
 	}
-	builder.WriteByte('"')
+
+	if preferredVotes == 0 || tied {
+		return url.URL{}, false
+	}
+	return preferredNode, true
 }
 
 type keyAffinity struct {
@@ -842,7 +732,7 @@ type keyAffinity struct {
 	// and potentially updated via auto-discovery from CreateTable operations.
 	pkInfoMutex            sync.RWMutex
 	pkInfoPerTable         map[string]string
-	pkInfoUpdateInProgress bool
+	pkInfoUpdateInProgress map[string]struct{}
 }
 
 // SetPartitionKeyName stores partition key information for a table in a thread-safe manner.
@@ -859,22 +749,29 @@ func (k *keyAffinity) GetPartitionKeyName(tableName string) string {
 	return k.pkInfoPerTable[tableName]
 }
 
-func (k *keyAffinity) TriggerUpdateTablePKInformation(pkGetter func() (string, string)) {
+func (k *keyAffinity) TriggerUpdateTablePKInformation(tableName string, pkGetter func() (string, string)) {
 	k.pkInfoMutex.Lock()
 	defer k.pkInfoMutex.Unlock()
-	if !k.pkInfoUpdateInProgress {
-		k.pkInfoUpdateInProgress = true
-		go func() {
-			defer func() {
-				k.pkInfoUpdateInProgress = false
-			}()
-			if tableName, keyName := pkGetter(); tableName != "" && keyName != "" {
-				k.pkInfoMutex.Lock()
-				defer k.pkInfoMutex.Unlock()
-				k.pkInfoPerTable[tableName] = keyName
-			}
-		}()
+	if k.pkInfoUpdateInProgress == nil {
+		k.pkInfoUpdateInProgress = make(map[string]struct{})
 	}
+	if _, ok := k.pkInfoUpdateInProgress[tableName]; ok {
+		return
+	}
+	k.pkInfoUpdateInProgress[tableName] = struct{}{}
+
+	go func() {
+		defer func() {
+			k.pkInfoMutex.Lock()
+			delete(k.pkInfoUpdateInProgress, tableName)
+			k.pkInfoMutex.Unlock()
+		}()
+		if discoveredTableName, keyName := pkGetter(); discoveredTableName != "" && keyName != "" {
+			k.pkInfoMutex.Lock()
+			defer k.pkInfoMutex.Unlock()
+			k.pkInfoPerTable[discoveredTableName] = keyName
+		}
+	}()
 }
 
 // Clone returns copy of keyAffinity.

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -2,7 +2,6 @@ package sdkv2
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -11,7 +10,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -21,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/aws/smithy-go/middleware"
 	"github.com/klauspost/compress/gzip"
 
 	"github.com/scylladb/alternator-client-golang/shared"
@@ -1006,7 +1003,7 @@ func TestOptions(t *testing.T) {
 							{
 								DeleteRequest: &types.DeleteRequest{
 									Key: map[string]types.AttributeValue{
-										"id": &types.AttributeValueMemberS{Value: key + "-del"},
+										"id": &types.AttributeValueMemberS{Value: key},
 									},
 								},
 							},
@@ -1256,60 +1253,13 @@ func TestOptions(t *testing.T) {
 	})
 }
 
-func TestBatchWriteItemKeyRouteAffinityDeterministicHashForReorderedWrites(t *testing.T) {
+func TestBatchWriteItemKeyRouteAffinityVotingSelectsPreferredNode(t *testing.T) {
 	t.Parallel()
 
-	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
-	first := &dynamodb.BatchWriteItemInput{
-		RequestItems: map[string][]types.WriteRequest{
-			"orders": {
-				{
-					PutRequest: &types.PutRequest{
-						Item: keyWithID("z-route"),
-					},
-				},
-				{
-					DeleteRequest: &types.DeleteRequest{
-						Key: keyWithID("a-route"),
-					},
-				},
-			},
-		},
-	}
-	second := &dynamodb.BatchWriteItemInput{
-		RequestItems: map[string][]types.WriteRequest{
-			"orders": {
-				{
-					DeleteRequest: &types.DeleteRequest{
-						Key: keyWithID("a-route"),
-					},
-				},
-				{
-					PutRequest: &types.PutRequest{
-						Item: keyWithID("z-route"),
-					},
-				},
-			},
-		},
-	}
-
-	firstHash := mustBatchWriteHash(t, h, first)
-	secondHash := mustBatchWriteHash(t, h, second)
-	expectedHash, err := HashAttributeValue(&types.AttributeValueMemberS{Value: "a-route"})
-	if err != nil {
-		t.Fatalf("HashAttributeValue returned error: %v", err)
-	}
-
-	if firstHash != expectedHash {
-		t.Fatalf("expected first request to use hash %d, got %d", expectedHash, firstHash)
-	}
-	if secondHash != expectedHash {
-		t.Fatalf("expected second request to use hash %d, got %d", expectedHash, secondHash)
-	}
-}
-
-func TestBatchWriteItemKeyRouteAffinityDeterministicHashForTableOrder(t *testing.T) {
-	t.Parallel()
+	target := batchWriteSortedTestNodes()[0]
+	other := batchWriteSortedTestNodes()[1]
+	targetKeys := batchWriteStringKeysForNode(t, target, 2)
+	otherKey := batchWriteStringKeysForNode(t, other, 1)[0]
 
 	h := newBatchWriteAffinityTestHelper(map[string]string{
 		"audit":  "id",
@@ -1320,212 +1270,203 @@ func TestBatchWriteItemKeyRouteAffinityDeterministicHashForTableOrder(t *testing
 			"orders": {
 				{
 					PutRequest: &types.PutRequest{
-						Item: itemWithID("orders-key"),
+						Item: itemWithID(targetKeys[0], "orders-payload"),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(otherKey),
 					},
 				},
 			},
 			"audit": {
 				{
 					PutRequest: &types.PutRequest{
-						Item: itemWithID("audit-key"),
+						Item: itemWithID(targetKeys[1], "audit-payload"),
 					},
 				},
 			},
 		},
 	}
 
-	expectedHash, err := HashAttributeValue(&types.AttributeValueMemberS{Value: "audit-key"})
-	if err != nil {
-		t.Fatalf("HashAttributeValue returned error: %v", err)
-	}
-
-	for i := 0; i < 50; i++ {
-		if hash := mustBatchWriteHash(t, h, input); hash != expectedHash {
-			t.Fatalf("iteration %d: expected hash %d, got %d", i, expectedHash, hash)
-		}
+	got := mustBatchWritePlanNodes(t, h, input, len(batchWriteTestNodes()))
+	want := append([]string{target.Host}, batchWriteSortedTestNodeHostsExcept(target)...)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected batch write query plan (-want +got):\n%s", diff)
 	}
 }
 
-func TestBatchWriteItemKeyRouteAffinityCrossLanguageVectors(t *testing.T) {
+func TestBatchWriteItemKeyRouteAffinityVotingStableForEquivalentBatches(t *testing.T) {
+	t.Parallel()
+
+	target := batchWriteSortedTestNodes()[0]
+	other := batchWriteSortedTestNodes()[1]
+	targetKeys := batchWriteStringKeysForNode(t, target, 2)
+	otherKey := batchWriteStringKeysForNode(t, other, 1)[0]
+
+	h := newBatchWriteAffinityTestHelper(map[string]string{
+		"audit":  "id",
+		"orders": "id",
+	})
+	first := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(targetKeys[0], "payload-a"),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(otherKey),
+					},
+				},
+			},
+			"audit": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(targetKeys[1], "payload-b"),
+					},
+				},
+			},
+		},
+	}
+	second := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"audit": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(targetKeys[1], "changed-audit-payload"),
+					},
+				},
+			},
+			"orders": {
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(otherKey),
+					},
+				},
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(targetKeys[0], "changed-orders-payload"),
+					},
+				},
+			},
+		},
+	}
+
+	firstNode := mustBatchWriteFirstNode(t, h, first)
+	secondNode := mustBatchWriteFirstNode(t, h, second)
+	if firstNode != target {
+		t.Fatalf("expected first request to select %s, got %s", target.Host, firstNode.Host)
+	}
+	if secondNode != firstNode {
+		t.Fatalf("expected equivalent reordered request to select %s, got %s", firstNode.Host, secondNode.Host)
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityVotingFallsBackOnTie(t *testing.T) {
+	t.Parallel()
+
+	nodes := batchWriteSortedTestNodes()
+	leftKey := batchWriteStringKeysForNode(t, nodes[0], 1)[0]
+	rightKey := batchWriteStringKeysForNode(t, nodes[1], 1)[0]
+
+	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
+	input := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(leftKey, "left"),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(rightKey),
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := h.batchWriteQueryPlan(input.RequestItems); err == nil {
+		t.Fatal("expected tied top vote count to fall back to non-affinity routing")
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityVotingSkipsUnusableCandidates(t *testing.T) {
+	t.Parallel()
+
+	target := batchWriteSortedTestNodes()[0]
+	targetKey := batchWriteStringKeysForNode(t, target, 1)[0]
+	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
+	h.keyAffinity.pkInfoUpdateInProgress = map[string]struct{}{"unknown": {}}
+
+	input := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"unknown": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID("missing-metadata", "ignored"),
+					},
+				},
+			},
+			"orders": {
+				{},
+				{
+					PutRequest: &types.PutRequest{},
+				},
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"id": &types.AttributeValueMemberS{Value: "invalid"},
+						},
+					},
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID("invalid"),
+					},
+				},
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"id": &types.AttributeValueMemberBOOL{Value: true},
+						},
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(targetKey),
+					},
+				},
+			},
+		},
+	}
+
+	node := mustBatchWriteFirstNode(t, h, input)
+	if node != target {
+		t.Fatalf("expected valid candidate to select %s, got %s", target.Host, node.Host)
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityVotingSupportsPartitionKeyTypes(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name          string
-		input         *dynamodb.BatchWriteItemInput
-		pkInfo        map[string]string
-		tableName     string
-		operation     string
-		pkLabel       string
-		canonical     string
-		hashSigned    int64
-		hashUnsigned  uint64
-		firstSixNodes []string
+		name  string
+		value types.AttributeValue
 	}{
 		{
-			name: "same_table_write_order",
-			input: &dynamodb.BatchWriteItemInput{
-				RequestItems: map[string][]types.WriteRequest{
-					"orders": {
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberS{Value: "order456"},
-								},
-							},
-						},
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberS{Value: "order123"},
-								},
-							},
-						},
-					},
-				},
-			},
-			pkInfo:        map[string]string{"orders": "pk"},
-			tableName:     "orders",
-			operation:     "PutRequest",
-			pkLabel:       "S:order123",
-			canonical:     `{"pk":{"S":"order123"}}`,
-			hashSigned:    -2126891002421145093,
-			hashUnsigned:  16319853071288406523,
-			firstSixNodes: []string{"node9", "node2", "node10", "node8", "node7", "node5"},
+			name:  "string_partition_key",
+			value: &types.AttributeValueMemberS{Value: "string-key"},
 		},
 		{
-			name: "multi_table_order",
-			input: &dynamodb.BatchWriteItemInput{
-				RequestItems: map[string][]types.WriteRequest{
-					"sessions": {
-						{
-							DeleteRequest: &types.DeleteRequest{
-								Key: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberS{Value: "session123"},
-								},
-							},
-						},
-					},
-					"orders": {
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"data": &types.AttributeValueMemberS{Value: "value"},
-									"pk":   &types.AttributeValueMemberS{Value: "order456"},
-								},
-							},
-						},
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk":   &types.AttributeValueMemberS{Value: "order123"},
-									"data": &types.AttributeValueMemberS{Value: "value"},
-								},
-							},
-						},
-					},
-				},
-			},
-			pkInfo:        map[string]string{"orders": "pk", "sessions": "pk"},
-			tableName:     "orders",
-			operation:     "PutRequest",
-			pkLabel:       "S:order123",
-			canonical:     `{"data":{"S":"value"},"pk":{"S":"order123"}}`,
-			hashSigned:    -2126891002421145093,
-			hashUnsigned:  16319853071288406523,
-			firstSixNodes: []string{"node9", "node2", "node10", "node8", "node7", "node5"},
+			name:  "number_partition_key",
+			value: &types.AttributeValueMemberN{Value: "42"},
 		},
 		{
-			name: "delete_put_same_attributes",
-			input: &dynamodb.BatchWriteItemInput{
-				RequestItems: map[string][]types.WriteRequest{
-					"orders": {
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberS{Value: "same"},
-								},
-							},
-						},
-						{
-							DeleteRequest: &types.DeleteRequest{
-								Key: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberS{Value: "same"},
-								},
-							},
-						},
-					},
-				},
-			},
-			pkInfo:        map[string]string{"orders": "pk"},
-			tableName:     "orders",
-			operation:     "DeleteRequest",
-			pkLabel:       "S:same",
-			canonical:     `{"pk":{"S":"same"}}`,
-			hashSigned:    -4879317772220196571,
-			hashUnsigned:  13567426301489355045,
-			firstSixNodes: []string{"node1", "node3", "node10", "node7", "node4", "node5"},
-		},
-		{
-			name: "number_partition_key",
-			input: &dynamodb.BatchWriteItemInput{
-				RequestItems: map[string][]types.WriteRequest{
-					"accounts": {
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberN{Value: "7"},
-								},
-							},
-						},
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberN{Value: "42"},
-								},
-							},
-						},
-					},
-				},
-			},
-			pkInfo:        map[string]string{"accounts": "pk"},
-			tableName:     "accounts",
-			operation:     "PutRequest",
-			pkLabel:       "N:42",
-			canonical:     `{"pk":{"N":"42"}}`,
-			hashSigned:    -5061732451827723051,
-			hashUnsigned:  13385011621881828565,
-			firstSixNodes: []string{"node3", "node7", "node1", "node10", "node2", "node5"},
-		},
-		{
-			name: "binary_partition_key",
-			input: &dynamodb.BatchWriteItemInput{
-				RequestItems: map[string][]types.WriteRequest{
-					"blobs": {
-						{
-							PutRequest: &types.PutRequest{
-								Item: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberB{Value: []byte{0x01, 0x02, 0x03}},
-								},
-							},
-						},
-						{
-							DeleteRequest: &types.DeleteRequest{
-								Key: map[string]types.AttributeValue{
-									"pk": &types.AttributeValueMemberB{Value: []byte{0x00, 0xff}},
-								},
-							},
-						},
-					},
-				},
-			},
-			pkInfo:        map[string]string{"blobs": "pk"},
-			tableName:     "blobs",
-			operation:     "DeleteRequest",
-			pkLabel:       "B:00ff",
-			canonical:     `{"pk":{"B":{"__bytes__":"00ff"}}}`,
-			hashSigned:    -4376945693382523102,
-			hashUnsigned:  14069798380327028514,
-			firstSixNodes: []string{"node7", "node2", "node5", "node1", "node6", "node9"},
+			name:  "binary_partition_key",
+			value: &types.AttributeValueMemberB{Value: []byte{0x00, 0xff}},
 		},
 	}
 
@@ -1534,41 +1475,25 @@ func TestBatchWriteItemKeyRouteAffinityCrossLanguageVectors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			targets := selectBatchWriteRoutingTargets(tt.input.RequestItems)
-			if len(targets) == 0 {
-				t.Fatal("expected at least one batch write routing target")
+			h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
+			input := &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					"orders": {
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"id": tt.value,
+								},
+							},
+						},
+					},
+				},
 			}
 
-			target := targets[0]
-			if target.tableName != tt.tableName {
-				t.Fatalf("expected table %q, got %q", tt.tableName, target.tableName)
-			}
-			if target.operation != tt.operation {
-				t.Fatalf("expected operation %q, got %q", tt.operation, target.operation)
-			}
-			if target.canonicalAttributes != tt.canonical {
-				t.Fatalf("expected canonical attributes %s, got %s", tt.canonical, target.canonicalAttributes)
-			}
-
-			pkName := tt.pkInfo[target.tableName]
-			pkValue, ok := target.values[pkName]
-			if !ok {
-				t.Fatalf("target does not contain partition key %q", pkName)
-			}
-			if label := batchWriteAttributeLabel(pkValue); label != tt.pkLabel {
-				t.Fatalf("expected pk %q, got %q", tt.pkLabel, label)
-			}
-
-			hash := mustBatchWriteHash(t, newBatchWriteAffinityTestHelper(tt.pkInfo), tt.input)
-			if hash != tt.hashSigned {
-				t.Fatalf("expected signed hash %d, got %d", tt.hashSigned, hash)
-			}
-			if unsigned := uint64(hash); unsigned != tt.hashUnsigned {
-				t.Fatalf("expected unsigned hash %d, got %d", tt.hashUnsigned, unsigned)
-			}
-
-			if diff := cmp.Diff(tt.firstSixNodes, batchWriteAffinityNodeSequence(hash, 6)); diff != "" {
-				t.Fatalf("unexpected node sequence (-want +got):\n%s", diff)
+			want := batchWriteNodeForValue(t, tt.value)
+			got := mustBatchWriteFirstNode(t, h, input)
+			if got != want {
+				t.Fatalf("expected %s, got %s", want.Host, got.Host)
 			}
 		})
 	}
@@ -1579,75 +1504,51 @@ func newBatchWriteAffinityTestHelper(pkInfo map[string]string) *Helper {
 	cfg.KeyRouteAffinity = shared.NewKeyRouteAffinityConfig(shared.KeyRouteAffinityAnyWrite).WithPkInfo(pkInfo)
 
 	return &Helper{
-		cfg: *cfg,
+		cfg:   *cfg,
+		nodes: batchWriteAffinityNodeSource{activeNodes: batchWriteTestNodes()},
 		keyAffinity: keyAffinity{
 			pkInfoPerTable: pkInfo,
 		},
 	}
 }
 
-func mustBatchWriteHash(t *testing.T, h *Helper, input *dynamodb.BatchWriteItemInput) int64 {
+func mustBatchWriteFirstNode(t *testing.T, h *Helper, input *dynamodb.BatchWriteItemInput) url.URL {
 	t.Helper()
 
-	hash, err := h.getPkHash(middleware.InitializeInput{Parameters: input})
+	plan, err := h.batchWriteQueryPlan(input.RequestItems)
 	if err != nil {
-		t.Fatalf("getPkHash returned error: %v", err)
+		t.Fatalf("batchWriteQueryPlan returned error: %v", err)
 	}
-	return hash
-}
-
-func batchWriteAttributeLabel(value types.AttributeValue) string {
-	switch value := value.(type) {
-	case *types.AttributeValueMemberS:
-		return "S:" + value.Value
-	case *types.AttributeValueMemberN:
-		return "N:" + value.Value
-	case *types.AttributeValueMemberB:
-		return "B:" + hex.EncodeToString(value.Value)
-	default:
-		return fmt.Sprintf("%T", value)
+	node := plan.Next()
+	if node.Host == "" {
+		t.Fatal("batch write query plan returned no first node")
 	}
+	return node
 }
 
-type batchWriteAffinityNodeSource struct {
-	activeNodes []url.URL
-}
+func mustBatchWritePlanNodes(t *testing.T, h *Helper, input *dynamodb.BatchWriteItemInput, count int) []string {
+	t.Helper()
 
-func (s batchWriteAffinityNodeSource) GetActiveNodes() []url.URL {
-	return append([]url.URL(nil), s.activeNodes...)
-}
-
-func (s batchWriteAffinityNodeSource) GetQuarantinedNodes() []url.URL {
-	return nil
-}
-
-func batchWriteAffinityNodeSequence(seed int64, count int) []string {
-	source := batchWriteAffinityNodeSource{
-		activeNodes: make([]url.URL, 0, 10),
-	}
-	for i := 1; i <= 10; i++ {
-		source.activeNodes = append(source.activeNodes, url.URL{
-			Scheme: "http",
-			Host:   fmt.Sprintf("node%d.example.com:8000", i),
-		})
+	plan, err := h.batchWriteQueryPlan(input.RequestItems)
+	if err != nil {
+		t.Fatalf("batchWriteQueryPlan returned error: %v", err)
 	}
 
-	plan := shared.NewLazyQueryPlanWithSeed(source, seed)
 	nodes := make([]string, 0, count)
 	for i := 0; i < count; i++ {
 		node := plan.Next()
 		if node.Host == "" {
 			break
 		}
-		host, _, _ := strings.Cut(node.Hostname(), ".")
-		nodes = append(nodes, host)
+		nodes = append(nodes, node.Host)
 	}
 	return nodes
 }
 
-func itemWithID(value string) map[string]types.AttributeValue {
-	item := keyWithID(value)
+func itemWithID(id, payload string) map[string]types.AttributeValue {
+	item := keyWithID(id)
 	item["data"] = &types.AttributeValueMemberS{Value: "payload"}
+	item["payload"] = &types.AttributeValueMemberS{Value: payload}
 	return item
 }
 
@@ -1655,6 +1556,109 @@ func keyWithID(value string) map[string]types.AttributeValue {
 	return map[string]types.AttributeValue{
 		"id": &types.AttributeValueMemberS{Value: value},
 	}
+}
+
+func batchWriteNodeForValue(t *testing.T, value types.AttributeValue) url.URL {
+	t.Helper()
+
+	hash, err := HashAttributeValue(value)
+	if err != nil {
+		t.Fatalf("HashAttributeValue returned error: %v", err)
+	}
+	return shared.FirstNodeWithSeed(batchWriteTestNodes(), hash)
+}
+
+func batchWriteStringKeysForNode(t *testing.T, target url.URL, count int) []string {
+	t.Helper()
+
+	keys := make([]string, 0, count)
+	for i := 0; i < 10000 && len(keys) < count; i++ {
+		key := fmt.Sprintf("%s-key-%d", target.Hostname(), i)
+		node := batchWriteNodeForValue(t, &types.AttributeValueMemberS{Value: key})
+		if node == target {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) != count {
+		t.Fatalf("found %d keys for %s, want %d", len(keys), target.Host, count)
+	}
+	return keys
+}
+
+type batchWriteAffinityNodeSource struct {
+	activeNodes      []url.URL
+	quarantinedNodes []url.URL
+}
+
+func (s batchWriteAffinityNodeSource) NextNode() url.URL {
+	return s.activeNodes[0]
+}
+
+func (s batchWriteAffinityNodeSource) GetNodes() []url.URL {
+	nodes := append([]url.URL(nil), s.activeNodes...)
+	nodes = append(nodes, s.quarantinedNodes...)
+	return nodes
+}
+
+func (s batchWriteAffinityNodeSource) GetActiveNodes() []url.URL {
+	return append([]url.URL(nil), s.activeNodes...)
+}
+
+func (s batchWriteAffinityNodeSource) GetQuarantinedNodes() []url.URL {
+	return append([]url.URL(nil), s.quarantinedNodes...)
+}
+
+func (s batchWriteAffinityNodeSource) UpdateLiveNodes() error {
+	return nil
+}
+
+func (s batchWriteAffinityNodeSource) ReportNodeError(url.URL, error) {
+}
+
+func (s batchWriteAffinityNodeSource) TryReleaseQuarantinedNodes() []url.URL {
+	return nil
+}
+
+func (s batchWriteAffinityNodeSource) CheckIfRackAndDatacenterSetCorrectly() error {
+	return nil
+}
+
+func (s batchWriteAffinityNodeSource) CheckIfRackDatacenterFeatureIsSupported() (bool, error) {
+	return true, nil
+}
+
+func (s batchWriteAffinityNodeSource) Start() {
+}
+
+func (s batchWriteAffinityNodeSource) Stop() {
+}
+
+func batchWriteTestNodes() []url.URL {
+	return []url.URL{
+		{Scheme: "http", Host: "node2.example.com:8000"},
+		{Scheme: "http", Host: "node10.example.com:8000"},
+		{Scheme: "http", Host: "node1.example.com:8000"},
+		{Scheme: "http", Host: "node3.example.com:8000"},
+	}
+}
+
+func batchWriteSortedTestNodes() []url.URL {
+	nodes := batchWriteTestNodes()
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].String() < nodes[j].String()
+	})
+	return nodes
+}
+
+func batchWriteSortedTestNodeHostsExcept(except url.URL) []string {
+	nodes := batchWriteSortedTestNodes()
+	hosts := make([]string, 0, len(nodes)-1)
+	for _, node := range nodes {
+		if node != except {
+			hosts = append(hosts, node.Host)
+		}
+	}
+	return hosts
 }
 
 func sortNodes(nodes []url.URL) []url.URL {

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -1253,6 +1253,149 @@ func TestOptions(t *testing.T) {
 	})
 }
 
+func TestBatchWriteItemKeyRouteAffinityRoutingCandidates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single_table_put", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := selectBatchWriteRoutingCandidates(map[string][]types.WriteRequest{
+			"t": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"pk":    &types.AttributeValueMemberS{Value: "put_key"},
+							"other": &types.AttributeValueMemberS{Value: "x"},
+						},
+					},
+				},
+			},
+		})
+
+		if len(candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(candidates))
+		}
+		requireBatchWriteCandidate(t, candidates, "t", "pk", "put_key")
+	})
+
+	t.Run("single_table_delete", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := selectBatchWriteRoutingCandidates(map[string][]types.WriteRequest{
+			"t": {
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "delete_key"},
+						},
+					},
+				},
+			},
+		})
+
+		if len(candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(candidates))
+		}
+		requireBatchWriteCandidate(t, candidates, "t", "pk", "delete_key")
+	})
+
+	t.Run("requests_without_pk_stay_candidates", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := selectBatchWriteRoutingCandidates(map[string][]types.WriteRequest{
+			"t": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"other": &types.AttributeValueMemberS{Value: "x"},
+						},
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "delete_key"},
+						},
+					},
+				},
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "put_key"},
+						},
+					},
+				},
+			},
+		})
+
+		if len(candidates) != 3 {
+			t.Fatalf("expected 3 candidates, got %d", len(candidates))
+		}
+		requireBatchWriteCandidateWithoutPK(t, candidates, "t", "pk")
+		requireBatchWriteCandidate(t, candidates, "t", "pk", "delete_key")
+		requireBatchWriteCandidate(t, candidates, "t", "pk", "put_key")
+	})
+
+	t.Run("multiple_tables", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := selectBatchWriteRoutingCandidates(map[string][]types.WriteRequest{
+			"z_table": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "z_key"},
+						},
+					},
+				},
+			},
+			"a_table": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "a_key"},
+						},
+					},
+				},
+			},
+		})
+
+		if len(candidates) != 2 {
+			t.Fatalf("expected 2 candidates, got %d", len(candidates))
+		}
+		requireBatchWriteCandidate(t, candidates, "a_table", "pk", "a_key")
+		requireBatchWriteCandidate(t, candidates, "z_table", "pk", "z_key")
+	})
+
+	t.Run("empty_and_invalid_requests_ignored", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := selectBatchWriteRoutingCandidates(map[string][]types.WriteRequest{
+			"t": {
+				{},
+				{PutRequest: &types.PutRequest{}},
+				{DeleteRequest: &types.DeleteRequest{}},
+				{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "invalid"},
+						},
+					},
+					DeleteRequest: &types.DeleteRequest{
+						Key: map[string]types.AttributeValue{
+							"pk": &types.AttributeValueMemberS{Value: "invalid"},
+						},
+					},
+				},
+			},
+		})
+
+		if len(candidates) != 0 {
+			t.Fatalf("expected no candidates, got %d", len(candidates))
+		}
+	})
+}
+
 func TestBatchWriteItemKeyRouteAffinityVotingSelectsPreferredNode(t *testing.T) {
 	t.Parallel()
 
@@ -1293,6 +1436,43 @@ func TestBatchWriteItemKeyRouteAffinityVotingSelectsPreferredNode(t *testing.T) 
 	want := append([]string{target.Host}, batchWriteSortedTestNodeHostsExcept(target)...)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("unexpected batch write query plan (-want +got):\n%s", diff)
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityVotingDeleteMajoritySelectsPreferredNode(t *testing.T) {
+	t.Parallel()
+
+	target := batchWriteSortedTestNodes()[0]
+	other := batchWriteSortedTestNodes()[1]
+	targetKeys := batchWriteStringKeysForNode(t, target, 2)
+	otherKey := batchWriteStringKeysForNode(t, other, 1)[0]
+
+	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
+	input := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(targetKeys[0]),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(otherKey),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(targetKeys[1]),
+					},
+				},
+			},
+		},
+	}
+
+	node := mustBatchWriteFirstNode(t, h, input)
+	if node != target {
+		t.Fatalf("expected delete majority to select %s, got %s", target.Host, node.Host)
 	}
 }
 
@@ -1556,6 +1736,42 @@ func keyWithID(value string) map[string]types.AttributeValue {
 	return map[string]types.AttributeValue{
 		"id": &types.AttributeValueMemberS{Value: value},
 	}
+}
+
+func requireBatchWriteCandidate(
+	t *testing.T,
+	candidates []batchWriteRoutingCandidate,
+	tableName, pkName, value string,
+) {
+	t.Helper()
+
+	for _, candidate := range candidates {
+		if candidate.tableName != tableName {
+			continue
+		}
+		if got, ok := candidate.values[pkName].(*types.AttributeValueMemberS); ok && got.Value == value {
+			return
+		}
+	}
+	t.Fatalf("candidate with table %q and %s=%q not found in %#v", tableName, pkName, value, candidates)
+}
+
+func requireBatchWriteCandidateWithoutPK(
+	t *testing.T,
+	candidates []batchWriteRoutingCandidate,
+	tableName, pkName string,
+) {
+	t.Helper()
+
+	for _, candidate := range candidates {
+		if candidate.tableName != tableName {
+			continue
+		}
+		if _, ok := candidate.values[pkName]; !ok {
+			return
+		}
+	}
+	t.Fatalf("candidate with table %q and no %q not found in %#v", tableName, pkName, candidates)
 }
 
 func batchWriteNodeForValue(t *testing.T, value types.AttributeValue) url.URL {

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -306,6 +307,7 @@ func NewAlternatorLiveNodes(initialNodes []string, options ...ALNOption) (*Alter
 		}
 		nodes[i] = *parsed
 	}
+	sortNodesByAddress(nodes)
 
 	nodeHealthStore, err := nodeshealth.NewNodeHealthStore(
 		cfg.NodeHealthStoreConfig,
@@ -423,7 +425,7 @@ func (aln *AlternatorLiveNodes) GetNodes() []url.URL {
 	// Return a copy to prevent external modifications
 	result := make([]url.URL, len(nodes))
 	copy(result, nodes)
-	return result
+	return sortNodesByAddress(result)
 }
 
 func (aln *AlternatorLiveNodes) nextAsURLWithPath(path, query string) *url.URL {
@@ -489,6 +491,7 @@ func (aln *AlternatorLiveNodes) UpdateLiveNodes() error {
 			aln.nodeHealthStore.RemoveNode(node)
 		}
 	}
+	sortNodesByAddress(newNodes)
 	aln.liveNodes.Store(&newNodes)
 	if hasNewNodes {
 		aln.nodeHealthStore.TryReleaseQuarantinedNodes()
@@ -524,7 +527,14 @@ func (aln *AlternatorLiveNodes) getNodes(endpoint *url.URL) ([]url.URL, error) {
 		}
 		uris = append(uris, *nodeURL)
 	}
-	return uris, nil
+	return sortNodesByAddress(uris), nil
+}
+
+func sortNodesByAddress(nodes []url.URL) []url.URL {
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].String() < nodes[j].String()
+	})
+	return nodes
 }
 
 // CheckIfRackAndDatacenterSetCorrectly verifies that the rack and datacenter

--- a/shared/query_plan.go
+++ b/shared/query_plan.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"math/rand"
 	"net/url"
+	"sort"
 	"time"
 )
 
@@ -15,10 +16,14 @@ type nodesSource interface {
 // It defers fetching active and quarantined nodes from the source until the first
 // time they are needed by Next().
 type LazyQueryPlan struct {
-	nodes            nodesSource
-	activeNodes      []url.URL
-	quarantinedNodes []url.URL
-	rnd              *rand.Rand
+	nodes              nodesSource
+	activeNodes        []url.URL
+	quarantinedNodes   []url.URL
+	rnd                *rand.Rand
+	preferredNode      url.URL
+	hasPreferredNode   bool
+	deterministicOrder bool
+	sortNodes          bool
 }
 
 // NewLazyQueryPlan constructs a plan bound to the provided nodes source.
@@ -37,19 +42,59 @@ func NewLazyQueryPlanWithSeed(nodes nodesSource, seed int64) *LazyQueryPlan {
 	}
 }
 
+// NewLazyQueryPlanWithSortedSeed constructs a seeded plan that sorts node
+// addresses lexicographically before applying the seeded selection algorithm.
+func NewLazyQueryPlanWithSortedSeed(nodes nodesSource, seed int64) *LazyQueryPlan {
+	return &LazyQueryPlan{
+		nodes:     nodes,
+		rnd:       rand.New(rand.NewSource(seed)),
+		sortNodes: true,
+	}
+}
+
+// NewLazyQueryPlanWithPreferredNode constructs a deterministic plan that tries
+// preferredNode first when it is still active, then the remaining nodes in
+// lexicographic address order.
+func NewLazyQueryPlanWithPreferredNode(nodes nodesSource, preferredNode url.URL) *LazyQueryPlan {
+	return &LazyQueryPlan{
+		nodes:              nodes,
+		rnd:                rand.New(rand.NewSource(0)),
+		preferredNode:      preferredNode,
+		hasPreferredNode:   preferredNode.Host != "",
+		deterministicOrder: true,
+		sortNodes:          true,
+	}
+}
+
+// FirstNodeWithSeed returns the first node selected by the seeded affinity
+// algorithm over a lexicographically sorted copy of nodes.
+func FirstNodeWithSeed(nodes []url.URL, seed int64) url.URL {
+	nodes = cloneAndSortNodes(nodes)
+	if len(nodes) == 0 {
+		return url.URL{}
+	}
+	return nodes[rand.New(rand.NewSource(seed)).Intn(len(nodes))]
+}
+
 // Next returns the next node to try. It iterates over active nodes first and then
 // quarantined nodes, picking a random node from the remaining pool and removing it
 // so that a node is never returned twice. If no nodes remain, it returns the zero url.URL.
 func (p *LazyQueryPlan) Next() url.URL {
 	if p.activeNodes == nil {
-		p.activeNodes = makeSureNotNil(p.nodes.GetActiveNodes())
+		p.activeNodes = p.prepareNodes(p.nodes.GetActiveNodes())
+	}
+	if p.hasPreferredNode {
+		p.hasPreferredNode = false
+		if node, ok := popNode(&p.activeNodes, p.preferredNode); ok {
+			return node
+		}
 	}
 	if len(p.activeNodes) > 0 {
 		return p.pickAndRemove(&p.activeNodes)
 	}
 
 	if p.quarantinedNodes == nil {
-		p.quarantinedNodes = makeSureNotNil(p.nodes.GetQuarantinedNodes())
+		p.quarantinedNodes = p.prepareNodes(p.nodes.GetQuarantinedNodes())
 	}
 	if len(p.quarantinedNodes) > 0 {
 		return p.pickAndRemove(&p.quarantinedNodes)
@@ -59,6 +104,12 @@ func (p *LazyQueryPlan) Next() url.URL {
 }
 
 func (p *LazyQueryPlan) pickAndRemove(nodes *[]url.URL) url.URL {
+	if p.deterministicOrder {
+		node := (*nodes)[0]
+		*nodes = (*nodes)[1:]
+		return node
+	}
+
 	idx := p.rnd.Intn(len(*nodes))
 	node := (*nodes)[idx]
 	(*nodes)[idx] = (*nodes)[len(*nodes)-1]
@@ -66,9 +117,34 @@ func (p *LazyQueryPlan) pickAndRemove(nodes *[]url.URL) url.URL {
 	return node
 }
 
+func (p *LazyQueryPlan) prepareNodes(in []url.URL) []url.URL {
+	if p.sortNodes {
+		return cloneAndSortNodes(in)
+	}
+	return makeSureNotNil(in)
+}
+
 func makeSureNotNil(in []url.URL) []url.URL {
 	if in == nil {
 		return []url.URL{}
 	}
 	return in
+}
+
+func popNode(nodes *[]url.URL, preferred url.URL) (url.URL, bool) {
+	for i, node := range *nodes {
+		if node == preferred {
+			*nodes = append((*nodes)[:i], (*nodes)[i+1:]...)
+			return node, true
+		}
+	}
+	return url.URL{}, false
+}
+
+func cloneAndSortNodes(in []url.URL) []url.URL {
+	out := makeSureNotNil(append([]url.URL(nil), in...))
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].String() < out[j].String()
+	})
+	return out
 }

--- a/shared/query_plan_unit_test.go
+++ b/shared/query_plan_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"net/url"
+	"sort"
 	"testing"
 )
 
@@ -121,6 +122,110 @@ func TestLazyQueryPlan(t *testing.T) {
 			t.Fatalf("expected quarantined nodes fetched once, got %d", source.quarantinedCalls)
 		}
 	})
+
+	t.Run("PreferredNodeFirstThenSortedRemaining", func(t *testing.T) {
+		preferred := url.URL{Host: "b"}
+		source := &fakeNodesSource{
+			activeNodes:      []url.URL{{Host: "c"}, preferred, {Host: "a"}},
+			quarantinedNodes: []url.URL{{Host: "q2"}, {Host: "q1"}},
+		}
+
+		plan := NewLazyQueryPlanWithPreferredNode(source, preferred)
+		got := []string{
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+		}
+		want := []string{"b", "a", "c", "q1", "q2"}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
+			}
+		}
+	})
+
+	t.Run("PreferredNodeMissingUsesSortedActiveNodes", func(t *testing.T) {
+		source := &fakeNodesSource{
+			activeNodes: []url.URL{{Host: "c"}, {Host: "a"}, {Host: "b"}},
+		}
+
+		plan := NewLazyQueryPlanWithPreferredNode(source, url.URL{Host: "missing"})
+		got := []string{
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+		}
+		want := []string{"a", "b", "c"}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
+			}
+		}
+	})
+}
+
+func TestFirstNodeWithSeedUsesSortedNodeAddresses(t *testing.T) {
+	nodes := []url.URL{
+		{Scheme: "http", Host: "node2.example.com:8043"},
+		{Scheme: "http", Host: "node10.example.com:8043"},
+		{Scheme: "http", Host: "node1.example.com:8043"},
+	}
+	original := append([]url.URL(nil), nodes...)
+
+	const seed = int64(42)
+	sorted := append([]url.URL(nil), nodes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].String() < sorted[j].String()
+	})
+	want := sorted[rand.New(rand.NewSource(seed)).Intn(len(sorted))]
+
+	got := FirstNodeWithSeed(nodes, seed)
+	if got != want {
+		t.Fatalf("FirstNodeWithSeed got %s, want %s", got.Host, want.Host)
+	}
+	for i := range nodes {
+		if nodes[i] != original[i] {
+			t.Fatalf("FirstNodeWithSeed modified input: got %v, want %v", nodes, original)
+		}
+	}
+}
+
+func TestLazyQueryPlanWithSortedSeedUsesSortedNodeAddresses(t *testing.T) {
+	nodes := []url.URL{
+		{Scheme: "http", Host: "node2.example.com:8043"},
+		{Scheme: "http", Host: "node10.example.com:8043"},
+		{Scheme: "http", Host: "node1.example.com:8043"},
+		{Scheme: "http", Host: "node3.example.com:8043"},
+	}
+	source := &fakeNodesSource{activeNodes: nodes}
+
+	const seed = int64(42)
+	sorted := append([]url.URL(nil), nodes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].String() < sorted[j].String()
+	})
+
+	rnd := rand.New(rand.NewSource(seed))
+	want := make([]string, 0, len(sorted))
+	for len(sorted) > 0 {
+		idx := rnd.Intn(len(sorted))
+		want = append(want, sorted[idx].Host)
+		sorted[idx] = sorted[len(sorted)-1]
+		sorted = sorted[:len(sorted)-1]
+	}
+
+	plan := NewLazyQueryPlanWithSortedSeed(source, seed)
+	got := make([]string, 0, len(nodes))
+	for node := plan.Next(); node.Host != ""; node = plan.Next() {
+		got = append(got, node.Host)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
+		}
+	}
 }
 
 func makeTestNodes(prefix string, count int) []url.URL {
@@ -131,10 +236,11 @@ func makeTestNodes(prefix string, count int) []url.URL {
 	return nodes
 }
 
-// TestLazyQueryPlanCrossLanguageVectors verifies that LazyQueryPlan produces identical
-// node selection sequences for given seeds across all language implementations.
+// TestLazyQueryPlanCrossLanguageVectors verifies that the raw seeded plan produces
+// identical node selection sequences for given seeds across all language implementations.
 // These test vectors are defined in DRIVER-446 and must be kept in sync with the
-// Java (and future) implementations to ensure cross-language key route affinity.
+// Java (and future) implementations. Affinity callers use NewLazyQueryPlanWithSortedSeed
+// so node ordering is normalized before this raw algorithm is applied.
 //
 // The PRNG is Go's math/rand (Lagged Fibonacci Generator) with pick-and-remove selection.
 // See: https://scylladb.atlassian.net/browse/DRIVER-446


### PR DESCRIPTION
## Summary

Implements the DRIVER-656 BatchWriteItem key-route affinity algorithm for the Go client. BatchWriteItem now builds usable routing candidates, hashes only supported partition-key values, votes by the preferred first node from the sorted live-node list, selects a strict winner, and falls back to normal non-affinity routing when there is no usable candidate or the top vote count is tied.

Also updates shared query-plan support so affinity paths can normalize node ordering and build a deterministic preferred-node plan, while preserving the existing raw seeded query-plan behavior for non-affinity callers.

Refs #101
Jira: https://scylladb.atlassian.net/browse/DRIVER-656

## Tests

- `make check-golangci`
- `make test-unit`
