### PR TITLE
Add configurable user-agent handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ h, _ := helper.NewHelper(
 
 ## Distinctive features
 
+### User-Agent
+
+The SDK helpers set the DynamoDB request User-Agent so Alternator can identify the Go client driver and
+version, for example `scylladb-alternator-client-golang/v1.2.3`.
+
+You can override, suppress, or transform the User-Agent:
+```go
+h, _ := helper.NewHelper(
+    []string{"x.x.x.x"},
+    helper.WithUserAgentFunc(func(current string) string {
+        return current + " my-app/1.0.0"
+    }),
+)
+```
+
+Use `helper.WithUserAgent("my-app/1.0.0")` to set an exact value, or `helper.WithoutUserAgent()` to suppress it.
+When headers optimization is enabled, the configured User-Agent is kept in the optimized header allowlist.
+
 ### Headers optimization
 
 Alternator does not use all the headers that are normally used by DynamoDB.

--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -133,6 +134,15 @@ var (
 	// WithOptimizeHeaders makes DynamoDB client remove headers not used by Alternator reducing outgoing traffic
 	WithOptimizeHeaders = shared.WithOptimizeHeaders
 
+	// WithUserAgent sets an exact User-Agent header value for DynamoDB requests
+	WithUserAgent = shared.WithUserAgent
+
+	// WithoutUserAgent suppresses the User-Agent header for DynamoDB requests
+	WithoutUserAgent = shared.WithoutUserAgent
+
+	// WithUserAgentFunc updates the User-Agent header for DynamoDB requests
+	WithUserAgentFunc = shared.WithUserAgentFunc
+
 	// WithRequestCompression enables request body compression with the specified algorithm.
 	// Currently supported algorithms: "gzip"
 	WithRequestCompression = shared.WithRequestCompression
@@ -142,6 +152,11 @@ var (
 
 	// WithHTTPClientTimeout controls timeout for HTTP requests
 	WithHTTPClientTimeout = shared.WithHTTPClientTimeout
+)
+
+const (
+	sdkv1ModulePath       = "github.com/scylladb/alternator-client-golang/sdkv1"
+	sdkv1UserAgentProduct = "scylladb-alternator-client-golang"
 )
 
 // WithAWSConfigOptions lets callers mutate the generated aws.Config before it is used by the SDK.
@@ -191,6 +206,7 @@ type Helper struct {
 // and optional functional configuration options (e.g., AWS region, credentials, TLS).
 func NewHelper(initialNodes []string, options ...Option) (*Helper, error) {
 	cfg := shared.NewDefaultConfig()
+	shared.WithUserAgentFunc(defaultUserAgent)(cfg)
 	for _, opt := range options {
 		opt(cfg)
 	}
@@ -321,6 +337,33 @@ func (lb *Helper) NewDynamoDB() (*dynamodb.DynamoDB, error) {
 	client := dynamodb.New(sess)
 	lb.injectQueryPlan(client)
 	return client, nil
+}
+
+func defaultUserAgent(string) string {
+	return sdkv1UserAgentProduct + "/" + moduleVersion(sdkv1ModulePath)
+}
+
+func moduleVersion(modulePath string) string {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "devel"
+	}
+	if buildInfo.Main.Path == modulePath {
+		return normalizeModuleVersion(buildInfo.Main.Version)
+	}
+	for _, dep := range buildInfo.Deps {
+		if dep.Path == modulePath {
+			return normalizeModuleVersion(dep.Version)
+		}
+	}
+	return "devel"
+}
+
+func normalizeModuleVersion(version string) string {
+	if version == "" || version == "(devel)" {
+		return "devel"
+	}
+	return version
 }
 
 type roundTripper struct {

--- a/sdkv1/helper_unit_test.go
+++ b/sdkv1/helper_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -222,6 +223,109 @@ func TestOptions(t *testing.T) {
 		})
 	})
 
+	t.Run("WithUserAgentAndOptimizedHeaders", func(t *testing.T) {
+		testCases := []struct {
+			name        string
+			options     []Option
+			want        string
+			wantPresent bool
+		}{
+			{
+				name:        "Default",
+				want:        sdkv1UserAgentProduct + "/devel",
+				wantPresent: true,
+			},
+			{
+				name:        "Set",
+				options:     []Option{WithUserAgent("custom-client/1.2.3")},
+				want:        "custom-client/1.2.3",
+				wantPresent: true,
+			},
+			{
+				name: "Transform",
+				options: []Option{WithUserAgentFunc(func(current string) string {
+					return current + " app/4.5.6"
+				})},
+				want:        sdkv1UserAgentProduct + "/devel app/4.5.6",
+				wantPresent: true,
+			},
+			{
+				name:        "Remove",
+				options:     []Option{WithoutUserAgent()},
+				want:        "",
+				wantPresent: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				var (
+					alternatorRequests atomic.Int32
+					capturedHeaders    atomic.Pointer[http.Header]
+				)
+
+				nodes := []string{"node1.local"}
+				mockTransport := &mocks.MockRoundTripper{
+					AlternatorRequest: func(req *http.Request) (*http.Response, error) {
+						alternatorRequests.Add(1)
+						return resp.AlternatorNodesResponse(nodes, req)
+					},
+					NodeHealthRequest: resp.HealthCheckResponse,
+					DynamoDBRequest: func(req *http.Request) (*http.Response, error) {
+						headers := req.Header.Clone()
+						capturedHeaders.Store(&headers)
+						return resp.DynamoDBListTablesResponse([]string{"test-table"}, req)
+					},
+				}
+
+				options := []Option{
+					WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
+					WithCredentials("test-key", "test-secret"),
+					WithOptimizeHeaders(true),
+				}
+				options = append(options, tc.options...)
+
+				h, err := NewHelper([]string{"node1.local"}, options...)
+				if err != nil {
+					t.Fatalf("NewHelper returned error: %v", err)
+				}
+				defer h.Stop()
+
+				if err := h.UpdateLiveNodes(); err != nil {
+					t.Fatalf("UpdateLiveNodes returned error: %v", err)
+				}
+
+				client, err := h.NewDynamoDB()
+				if err != nil {
+					t.Fatalf("NewDynamoDB returned error: %v", err)
+				}
+
+				_, err = client.ListTables(&dynamodb.ListTablesInput{
+					Limit: aws.Int64(10),
+				})
+				if err != nil {
+					t.Fatalf("ListTables returned error: %v", err)
+				}
+
+				if alternatorRequests.Load() == 0 {
+					t.Fatal("expected Alternator discovery call to happen")
+				}
+
+				headers := capturedHeaders.Load()
+				if headers == nil {
+					t.Fatal("expected headers to be captured")
+				}
+				got := headers.Get("User-Agent")
+				if got != tc.want {
+					t.Fatalf("User-Agent = %q, want %q", got, tc.want)
+				}
+				if _, ok := (*headers)["User-Agent"]; ok != tc.wantPresent {
+					t.Fatalf("User-Agent presence = %t, want %t", ok, tc.wantPresent)
+				}
+			})
+		}
+	})
+
 	t.Run("WithGzipRequestCompression", func(t *testing.T) {
 		t.Parallel()
 
@@ -345,8 +449,9 @@ func TestOptions(t *testing.T) {
 				}
 
 				if tc.optimizeHeaders {
-					if headers.Get("User-Agent") != "" {
-						t.Error("User-Agent header should be removed with header optimization")
+					userAgent := headers.Get("User-Agent")
+					if !strings.Contains(userAgent, sdkv1UserAgentProduct+"/devel") {
+						t.Errorf("User-Agent header should be retained with header optimization, got %q", userAgent)
 					}
 					if headers.Get("SignedHeaders") != "" {
 						t.Error("SignedHeaders header should be removed with header optimization")

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -127,6 +128,15 @@ var (
 	// WithCustomOptimizeHeaders makes DynamoDB client remove headers not used by Alternator reducing outgoing traffic
 	WithCustomOptimizeHeaders = shared.WithCustomOptimizeHeaders
 
+	// WithUserAgent sets an exact User-Agent header value for DynamoDB requests
+	WithUserAgent = shared.WithUserAgent
+
+	// WithoutUserAgent suppresses the User-Agent header for DynamoDB requests
+	WithoutUserAgent = shared.WithoutUserAgent
+
+	// WithUserAgentFunc updates the User-Agent header for DynamoDB requests
+	WithUserAgentFunc = shared.WithUserAgentFunc
+
 	// WithKeyLogWriter makes both (DynamoDB and Alternator) clients to write TLS master key into a file
 	// It helps to debug issues by looking at decoded HTTPS traffic between Alternator and client
 	WithKeyLogWriter = shared.WithKeyLogWriter
@@ -180,6 +190,11 @@ const (
 	KeyRouteAffinityAnyWrite = shared.KeyRouteAffinityAnyWrite
 )
 
+const (
+	sdkv2ModulePath       = "github.com/scylladb/alternator-client-golang/sdkv2"
+	sdkv2UserAgentProduct = "scylladb-alternator-client-golang"
+)
+
 // AlternatorNodesSource an interface for nodes list provider
 type AlternatorNodesSource interface {
 	NextNode() url.URL
@@ -221,6 +236,7 @@ type Helper struct {
 // and optional functional configuration options (e.g., AWS region, credentials, TLS).
 func NewHelper(initialNodes []string, options ...shared.Option) (*Helper, error) {
 	cfg := shared.NewDefaultConfig()
+	shared.WithUserAgentFunc(defaultUserAgent)(cfg)
 	for _, opt := range options {
 		opt(cfg)
 	}
@@ -347,6 +363,33 @@ func (lb *Helper) endpointResolverV2() dynamodb.EndpointResolverV2 {
 // GetPartitionKeyName retrieves partition key information for a table in a thread-safe manner.
 func (lb *Helper) GetPartitionKeyName(tableName string) string {
 	return lb.keyAffinity.GetPartitionKeyName(tableName)
+}
+
+func defaultUserAgent(string) string {
+	return sdkv2UserAgentProduct + "/" + moduleVersion(sdkv2ModulePath)
+}
+
+func moduleVersion(modulePath string) string {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "devel"
+	}
+	if buildInfo.Main.Path == modulePath {
+		return normalizeModuleVersion(buildInfo.Main.Version)
+	}
+	for _, dep := range buildInfo.Deps {
+		if dep.Path == modulePath {
+			return normalizeModuleVersion(dep.Version)
+		}
+	}
+	return "devel"
+}
+
+func normalizeModuleVersion(version string) string {
+	if version == "" || version == "(devel)" {
+		return "devel"
+	}
+	return version
 }
 
 // NewDynamoDB creates a new DynamoDB client preconfigured to route requests to Alternator nodes

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -228,6 +229,109 @@ func TestOptions(t *testing.T) {
 		})
 	})
 
+	t.Run("WithUserAgentAndOptimizedHeaders", func(t *testing.T) {
+		testCases := []struct {
+			name        string
+			options     []Option
+			want        string
+			wantPresent bool
+		}{
+			{
+				name:        "Default",
+				want:        sdkv2UserAgentProduct + "/devel",
+				wantPresent: true,
+			},
+			{
+				name:        "Set",
+				options:     []Option{WithUserAgent("custom-client/1.2.3")},
+				want:        "custom-client/1.2.3",
+				wantPresent: true,
+			},
+			{
+				name: "Transform",
+				options: []Option{WithUserAgentFunc(func(current string) string {
+					return current + " app/4.5.6"
+				})},
+				want:        sdkv2UserAgentProduct + "/devel app/4.5.6",
+				wantPresent: true,
+			},
+			{
+				name:        "Remove",
+				options:     []Option{WithoutUserAgent()},
+				want:        "",
+				wantPresent: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				var (
+					alternatorRequests atomic.Int32
+					capturedHeaders    atomic.Pointer[http.Header]
+				)
+
+				nodes := []string{"node1.local"}
+				mockTransport := &mocks.MockRoundTripper{
+					AlternatorRequest: func(req *http.Request) (*http.Response, error) {
+						alternatorRequests.Add(1)
+						return resp.AlternatorNodesResponse(nodes, req)
+					},
+					NodeHealthRequest: resp.HealthCheckResponse,
+					DynamoDBRequest: func(req *http.Request) (*http.Response, error) {
+						headers := req.Header.Clone()
+						capturedHeaders.Store(&headers)
+						return resp.DynamoDBListTablesResponse([]string{"test-table"}, req)
+					},
+				}
+
+				options := []Option{
+					WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
+					WithCredentials("test-key", "test-secret"),
+					WithOptimizeHeaders(true),
+				}
+				options = append(options, tc.options...)
+
+				h, err := NewHelper([]string{"node1.local"}, options...)
+				if err != nil {
+					t.Fatalf("NewHelper returned error: %v", err)
+				}
+				defer h.Stop()
+
+				if err := h.UpdateLiveNodes(); err != nil {
+					t.Fatalf("UpdateLiveNodes returned error: %v", err)
+				}
+
+				client, err := h.NewDynamoDB()
+				if err != nil {
+					t.Fatalf("NewDynamoDB returned error: %v", err)
+				}
+
+				_, err = client.ListTables(context.Background(), &dynamodb.ListTablesInput{
+					Limit: aws.Int32(10),
+				})
+				if err != nil {
+					t.Fatalf("ListTables returned error: %v", err)
+				}
+
+				if alternatorRequests.Load() == 0 {
+					t.Fatal("expected Alternator discovery call to happen")
+				}
+
+				headers := capturedHeaders.Load()
+				if headers == nil {
+					t.Fatal("expected headers to be captured")
+				}
+				got := headers.Get("User-Agent")
+				if got != tc.want {
+					t.Fatalf("User-Agent = %q, want %q", got, tc.want)
+				}
+				if _, ok := (*headers)["User-Agent"]; ok != tc.wantPresent {
+					t.Fatalf("User-Agent presence = %t, want %t", ok, tc.wantPresent)
+				}
+			})
+		}
+	})
+
 	t.Run("WithGzipRequestCompression", func(t *testing.T) {
 		t.Parallel()
 
@@ -351,8 +455,9 @@ func TestOptions(t *testing.T) {
 				}
 
 				if tc.optimizeHeaders {
-					if headers.Get("User-Agent") != "" {
-						t.Error("User-Agent header should be removed with header optimization")
+					userAgent := headers.Get("User-Agent")
+					if !strings.Contains(userAgent, sdkv2UserAgentProduct+"/devel") {
+						t.Errorf("User-Agent header should be retained with header optimization, got %q", userAgent)
 					}
 					if headers.Get("SignedHeaders") != "" {
 						t.Error("SignedHeaders header should be removed with header optimization")

--- a/shared/config.go
+++ b/shared/config.go
@@ -65,6 +65,8 @@ type Config struct {
 	HTTPClientTimeout time.Duration
 	// AWSConfigOptions holds []func(*aws.Config) where the aws.Config type differs for each SDK version (v1 vs v2)
 	AWSConfigOptions []any
+	// UserAgent updates the DynamoDB request User-Agent header.
+	UserAgent UserAgentFunc
 	// RequestCompression configures compression for request bodies
 	RequestCompression RequestCompressionFunc
 	// NodeHealthStoreConfig controls node health tracking logic
@@ -344,6 +346,9 @@ func WithOptimizeHeaders(enabled bool) Option {
 			if config.AccessKeyID != "" {
 				allowedHeaders = append(allowedHeaders, "Authorization", "X-Amz-Date")
 			}
+			if config.UserAgent != nil {
+				allowedHeaders = append(allowedHeaders, userAgentHeader)
+			}
 			return allowedHeaders
 		}
 	}
@@ -356,6 +361,39 @@ func WithOptimizeHeaders(enabled bool) Option {
 func WithCustomOptimizeHeaders(fn func(config Config) []string) Option {
 	return func(config *Config) {
 		config.OptimizeHeaders = fn
+	}
+}
+
+// WithUserAgent sets an exact User-Agent header value for DynamoDB requests.
+// An empty value suppresses the User-Agent header.
+func WithUserAgent(userAgent string) Option {
+	return func(config *Config) {
+		config.UserAgent = func(string) string {
+			return userAgent
+		}
+	}
+}
+
+// WithoutUserAgent suppresses the User-Agent header for DynamoDB requests.
+func WithoutUserAgent() Option {
+	return WithUserAgent("")
+}
+
+// WithUserAgentFunc updates the User-Agent header for DynamoDB requests.
+// The function receives the current value after earlier User-Agent options and may return an empty string to
+// suppress it.
+func WithUserAgentFunc(fn UserAgentFunc) Option {
+	if fn == nil {
+		panic("userAgentFunc can't be nil")
+	}
+	return func(config *Config) {
+		previous := config.UserAgent
+		config.UserAgent = func(current string) string {
+			if previous != nil {
+				current = previous(current)
+			}
+			return fn(current)
+		}
 	}
 }
 
@@ -508,6 +546,10 @@ func NewHTTPTransport(config Config) http.RoundTripper {
 			transport,
 			config.RequestCompression,
 		)
+	}
+
+	if config.UserAgent != nil {
+		transport = newUserAgentTransport(transport, config.UserAgent)
 	}
 
 	return transport

--- a/shared/user_agent.go
+++ b/shared/user_agent.go
@@ -1,0 +1,39 @@
+package shared
+
+import "net/http"
+
+const userAgentHeader = "User-Agent"
+
+// UserAgentFunc updates a request User-Agent value.
+// Returning an empty string suppresses the User-Agent header.
+type UserAgentFunc func(current string) string
+
+type userAgentTransport struct {
+	original http.RoundTripper
+	fn       UserAgentFunc
+}
+
+func newUserAgentTransport(original http.RoundTripper, fn UserAgentFunc) *userAgentTransport {
+	return &userAgentTransport{
+		original: original,
+		fn:       fn,
+	}
+}
+
+func (t userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	setRequestUserAgent(req, t.fn(req.Header.Get(userAgentHeader)))
+	return t.original.RoundTrip(req)
+}
+
+func setRequestUserAgent(req *http.Request, userAgent string) {
+	if userAgent == "" {
+		req.Header[userAgentHeader] = nil
+		return
+	}
+	req.Header.Set(userAgentHeader, userAgent)
+}
+
+var _ http.RoundTripper = userAgentTransport{}

--- a/shared/user_agent_test.go
+++ b/shared/user_agent_test.go
@@ -1,0 +1,175 @@
+package shared
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+)
+
+func TestUserAgentTransport_SetRemoveAndTransform(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		initial     string
+		fn          UserAgentFunc
+		want        string
+		wantPresent bool
+	}{
+		{
+			name:        "Set",
+			initial:     "aws-sdk-go/1.0",
+			fn:          func(string) string { return "custom-client/1.2.3" },
+			want:        "custom-client/1.2.3",
+			wantPresent: true,
+		},
+		{
+			name:        "Transform",
+			initial:     "aws-sdk-go/1.0",
+			fn:          func(current string) string { return current + " app/4.5.6" },
+			want:        "aws-sdk-go/1.0 app/4.5.6",
+			wantPresent: true,
+		},
+		{
+			name:        "Remove",
+			initial:     "aws-sdk-go/1.0",
+			fn:          func(string) string { return "" },
+			want:        "",
+			wantPresent: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedHeaders http.Header
+			transport := newUserAgentTransport(roundTripFunc(
+				func(req *http.Request) (*http.Response, error) {
+					capturedHeaders = req.Header.Clone()
+					return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+				},
+			), tc.fn)
+
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set(userAgentHeader, tc.initial)
+
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if got := capturedHeaders.Get(userAgentHeader); got != tc.want {
+				t.Fatalf("User-Agent = %q, want %q", got, tc.want)
+			}
+			if _, ok := capturedHeaders[userAgentHeader]; ok != tc.wantPresent {
+				t.Fatalf("User-Agent presence = %t, want %t", ok, tc.wantPresent)
+			}
+		})
+	}
+}
+
+func TestUserAgentTransport_RemoveSuppressesDefaultUserAgent(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		wrap func(http.RoundTripper) http.RoundTripper
+	}{
+		{
+			name: "Direct",
+			wrap: func(transport http.RoundTripper) http.RoundTripper {
+				return transport
+			},
+		},
+		{
+			name: "WithHeaderWhitelist",
+			wrap: func(transport http.RoundTripper) http.RoundTripper {
+				return NewHeaderWhiteListingTransport(transport, userAgentHeader)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resultCh := make(chan struct {
+				userAgent string
+				present   bool
+			}, 1)
+
+			server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+				_, present := req.Header[userAgentHeader]
+				resultCh <- struct {
+					userAgent string
+					present   bool
+				}{
+					userAgent: req.Header.Get(userAgentHeader),
+					present:   present,
+				}
+			}))
+			defer server.Close()
+
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			defer transport.CloseIdleConnections()
+
+			client := server.Client()
+			client.Transport = newUserAgentTransport(tc.wrap(transport), func(string) string {
+				return ""
+			})
+
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set(userAgentHeader, "aws-sdk-go/1.0")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			result := <-resultCh
+			if result.userAgent != "" {
+				t.Fatalf("User-Agent = %q, want empty", result.userAgent)
+			}
+			if result.present {
+				t.Fatal("User-Agent should be absent on the wire")
+			}
+		})
+	}
+}
+
+func TestWithUserAgentFunc_ComposesPreviousUserAgentOption(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewDefaultConfig()
+	WithUserAgent("custom-client/1.2.3")(cfg)
+	WithUserAgentFunc(func(current string) string {
+		return current + " app/4.5.6"
+	})(cfg)
+
+	if got := cfg.UserAgent("aws-sdk-go/1.0"); got != "custom-client/1.2.3 app/4.5.6" {
+		t.Fatalf("UserAgent() = %q", got)
+	}
+}
+
+func TestWithOptimizeHeaders_AllowsConfiguredUserAgent(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewDefaultConfig()
+	WithUserAgent("custom-client/1.2.3")(cfg)
+	WithOptimizeHeaders(true)(cfg)
+
+	if !slices.Contains(cfg.OptimizeHeaders(*cfg), userAgentHeader) {
+		t.Fatalf("optimized header allowlist should include %q when User-Agent is configured", userAgentHeader)
+	}
+}


### PR DESCRIPTION
## Why

Closes #3 / DRIVER-287.

Alternator needs a useful DynamoDB request User-Agent for client identification, while users still need control over what gets sent. Header optimization previously stripped `User-Agent`, so configured user-agent behavior also needed to be preserved through the optimized header allowlist.

## What changed

- Override the default DynamoDB request User-Agent for both helpers with a Go client driver product token:
  - `scylladb-alternator-client-golang/<module-version>`
- Add shared user-agent options and re-export them from both SDK packages:
  - `WithUserAgent(value)` for an exact value
  - `WithoutUserAgent()` to suppress the header
  - `WithUserAgentFunc(func(current string) string)` to transform the current value
- Keep configured `User-Agent` in the default optimized header allowlist.
- Suppress Go's fallback `Go-http-client/1.1` user-agent when callers remove the header.
- Document the new behavior in the README.

## Test evidence

- `make test-unit`
- `make check-golangci`