### PR TITLE
Fix routing fallback node discovery

### DIFF
--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -442,8 +442,8 @@ func (aln *AlternatorLiveNodes) nextAsURLWithPath(path, query string) *url.URL {
 func (aln *AlternatorLiveNodes) getLiveNodesNodes() ([]url.URL, error) {
 	scope := aln.cfg.RoutingScope
 
-	plan := NewLazyQueryPlan(aln)
 	for scope != nil {
+		plan := NewLazyQueryPlan(aln)
 		var lastErr error
 		for node := plan.Next(); node.Host != ""; node = plan.Next() {
 			endpoint := node

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -1,0 +1,74 @@
+package shared
+
+import (
+	"net/http"
+	"net/url"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/scylladb/alternator-client-golang/shared/rt"
+	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
+)
+
+func TestAlternatorLiveNodes_RoutingScopeFallbackRetriesKnownNodes(t *testing.T) {
+	t.Parallel()
+
+	var fallbackRequests atomic.Int32
+
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"node1.local", "node2.local"},
+		WithALNPort(8080),
+		WithALNRoutingScope(rt.NewDCScope("wrong", rt.NewDCScope("target", nil))),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "" || req.URL.Path == "/" {
+					return resp.HealthCheckResponse(req)
+				}
+				switch req.URL.RawQuery {
+				case "dc=wrong":
+					return resp.AlternatorNodesResponse(nil, req)
+				case "dc=target":
+					fallbackRequests.Add(1)
+					return resp.AlternatorNodesResponse([]string{"node3.local"}, req)
+				default:
+					t.Fatalf("unexpected /localnodes query %q", req.URL.RawQuery)
+					return nil, nil
+				}
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+	if got, want := aln.cfg.RoutingScope.String(), "Datacenter(dc=wrong)"; got != want {
+		t.Fatalf("RoutingScope got %q, want %q", got, want)
+	}
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+
+	got := hostnames(aln.GetNodes())
+	if !slices.Equal(got, []string{"node3.local"}) {
+		t.Fatalf("GetNodes got %v, want [node3.local]", got)
+	}
+	if fallbackRequests.Load() == 0 {
+		t.Fatalf("expected discovery request for fallback scope")
+	}
+}
+
+type liveNodesRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f liveNodesRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func hostnames(nodes []url.URL) []string {
+	out := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		out = append(out, node.Hostname())
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Recreate the live-node query plan for every routing fallback scope.
- Prevent the first scope from exhausting all known nodes and leaving broader fallback scopes with no endpoints to query.
- Add a regression test where `dc=wrong` returns no nodes and fallback `dc=target` discovers `node3.local`.

Refs #117. This fixes the client-side fallback exhaustion bug discussed there; it does not close the separate remote-DC topology discovery gap.

## Testing

- `go test ./shared/...`
- `go test ./...` in `sdkv1`
- `go test ./...` in `sdkv2`