### PR TITLE
Fix cluster-wide routing discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ lb, err := helper.NewHelper(
 )
 ```
 
+For cluster-wide routing, the helper queries the seed nodes passed to `NewHelper` and merges the returned node lists.
+Some Scylla versions return only the contacted node's datacenter from `/localnodes`, even with cluster scope. In that
+case, the seed list is assumed to contain working nodes from the datacenters that should be included:
+
+```golang
+lb, err := helper.NewHelper(
+    []string{"dc1-node.example.com", "dc2-node.example.com", "dc3-node.example.com"},
+    helper.WithRoutingScope(rt.NewClusterScope()),
+)
+```
+
 #### Deprecated Options
 
 The `WithRack` and `WithDatacenter` options are deprecated. Use `WithRoutingScope` instead:

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -443,7 +443,9 @@ func (aln *AlternatorLiveNodes) fetchLiveNodes() ([]url.URL, error) {
 	scope := aln.cfg.RoutingScope
 
 	for scope != nil {
+		clusterScope := rt.IsClusterScope(scope)
 		plan := NewLazyQueryPlan(aln)
+		var discoveredNodes []url.URL
 		var lastErr error
 		for node := plan.Next(); node.Host != ""; node = plan.Next() {
 			endpoint := node
@@ -456,8 +458,15 @@ func (aln *AlternatorLiveNodes) fetchLiveNodes() ([]url.URL, error) {
 				continue
 			}
 			if len(newNodes) != 0 {
+				if clusterScope {
+					discoveredNodes = append(discoveredNodes, newNodes...)
+					continue
+				}
 				return newNodes, nil
 			}
+		}
+		if len(discoveredNodes) != 0 {
+			return cloneAndDedupeNodes(discoveredNodes), nil
 		}
 		if lastErr != nil {
 			return nil, lastErr
@@ -537,6 +546,20 @@ func sortNodesByAddress(nodes []url.URL) []url.URL {
 	return nodes
 }
 
+func cloneAndDedupeNodes(nodes []url.URL) []url.URL {
+	out := make([]url.URL, 0, len(nodes))
+	seen := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		key := node.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, node)
+	}
+	return sortNodesByAddress(out)
+}
+
 // CheckIfRackAndDatacenterSetCorrectly verifies that the rack and datacenter
 // settings are correctly configured and recognized by the Alternator cluster.
 func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err error) {
@@ -550,7 +573,7 @@ func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err erro
 	}()
 	scope := aln.cfg.RoutingScope
 	for scope != nil {
-		if _, ok := scope.(rt.ClusterScope); ok {
+		if rt.IsClusterScope(scope) {
 			// Cluster scope does not require validation
 			return nil
 		}

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -59,6 +59,63 @@ func TestAlternatorLiveNodes_RoutingScopeFallbackRetriesKnownNodes(t *testing.T)
 	}
 }
 
+func TestAlternatorLiveNodes_ClusterScopeMergesSeedNodes(t *testing.T) {
+	t.Parallel()
+
+	var dc1Requests atomic.Int32
+	var dc2Requests atomic.Int32
+
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"dc1-node1.local", "dc2-node1.local"},
+		WithALNPort(8080),
+		WithALNRoutingScope(rt.NewClusterScope()),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "" || req.URL.Path == "/" {
+					return resp.HealthCheckResponse(req)
+				}
+				if req.URL.Path != "/localnodes" {
+					t.Fatalf("unexpected request path %q", req.URL.Path)
+				}
+				if req.URL.RawQuery != "" {
+					t.Fatalf("unexpected /localnodes query %q", req.URL.RawQuery)
+				}
+				switch req.URL.Hostname() {
+				case "dc1-node1.local":
+					dc1Requests.Add(1)
+					return resp.AlternatorNodesResponse([]string{"dc1-node1.local", "dc1-node2.local"}, req)
+				case "dc2-node1.local":
+					dc2Requests.Add(1)
+					return resp.AlternatorNodesResponse([]string{"dc2-node1.local", "dc2-node2.local"}, req)
+				default:
+					t.Fatalf("unexpected discovery host %q", req.URL.Hostname())
+					return nil, nil
+				}
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+
+	got := hostnames(aln.GetNodes())
+	want := []string{"dc1-node1.local", "dc1-node2.local", "dc2-node1.local", "dc2-node2.local"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("GetNodes got %v, want %v", got, want)
+	}
+	if dc1Requests.Load() == 0 {
+		t.Fatalf("expected discovery request for dc1 seed")
+	}
+	if dc2Requests.Load() == 0 {
+		t.Fatalf("expected discovery request for dc2 seed")
+	}
+}
+
 type liveNodesRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f liveNodesRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/shared/rt/routing_scope.go
+++ b/shared/rt/routing_scope.go
@@ -131,6 +131,16 @@ func NewClusterScope() *ClusterScope {
 	return &ClusterScope{}
 }
 
+// IsClusterScope reports whether scope targets the whole cluster.
+func IsClusterScope(scope Scope) bool {
+	switch scope.(type) {
+	case ClusterScope, *ClusterScope:
+		return true
+	default:
+		return false
+	}
+}
+
 // Name implements Scope.
 func (w ClusterScope) Name() string {
 	return "Cluster"


### PR DESCRIPTION
## Summary
- merge `/localnodes` responses from all cluster-scope seed endpoints instead of stopping after the first datacenter-local response
- use the nodes passed to `NewHelper` / `NewAlternatorLiveNodes` as the discovery seeds, assuming that list contains working nodes from the datacenters that should be included
- document the seed-list expectation and add unit coverage for merging DC-local `/localnodes` responses from seeds in different DCs

## Testing
- `make test-unit`
- `make check-golangci`

Fixes #117