### PR TITLE
Validate routing scopes across seeds

### DIFF
--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -443,35 +443,46 @@ func (aln *AlternatorLiveNodes) fetchLiveNodes() ([]url.URL, error) {
 	scope := aln.cfg.RoutingScope
 
 	for scope != nil {
-		clusterScope := rt.IsClusterScope(scope)
-		plan := NewLazyQueryPlan(aln)
-		var discoveredNodes []url.URL
-		var lastErr error
-		for node := plan.Next(); node.Host != ""; node = plan.Next() {
-			endpoint := node
-			endpoint.Path = "/localnodes"
-			endpoint.RawQuery = scope.GetLocalNodesQuery()
-
-			newNodes, err := aln.getNodes(&endpoint)
-			if err != nil {
-				lastErr = err
-				continue
-			}
-			if len(newNodes) != 0 {
-				if clusterScope {
-					discoveredNodes = append(discoveredNodes, newNodes...)
-					continue
-				}
-				return newNodes, nil
-			}
+		newNodes, err := aln.getNodesForScope(scope)
+		if err != nil {
+			return nil, err
 		}
-		if len(discoveredNodes) != 0 {
-			return cloneAndDedupeNodes(discoveredNodes), nil
-		}
-		if lastErr != nil {
-			return nil, lastErr
+		if len(newNodes) != 0 {
+			return newNodes, nil
 		}
 		scope = scope.Fallback()
+	}
+	return nil, nil
+}
+
+func (aln *AlternatorLiveNodes) getNodesForScope(scope rt.Scope) ([]url.URL, error) {
+	clusterScope := rt.IsClusterScope(scope)
+	plan := NewLazyQueryPlan(aln)
+	var discoveredNodes []url.URL
+	var lastErr error
+	for node := plan.Next(); node.Host != ""; node = plan.Next() {
+		endpoint := node
+		endpoint.Path = "/localnodes"
+		endpoint.RawQuery = scope.GetLocalNodesQuery()
+
+		newNodes, err := aln.getNodes(&endpoint)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(newNodes) == 0 {
+			continue
+		}
+		if !clusterScope {
+			return newNodes, nil
+		}
+		discoveredNodes = append(discoveredNodes, newNodes...)
+	}
+	if len(discoveredNodes) != 0 {
+		return cloneAndDedupeNodes(discoveredNodes), nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
 	}
 	return nil, nil
 }
@@ -577,7 +588,7 @@ func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err erro
 			// Cluster scope does not require validation
 			return nil
 		}
-		newNodes, err := aln.getNodes(aln.nextAsURLWithPath("/localnodes", scope.GetLocalNodesQuery()))
+		newNodes, err := aln.getNodesForScope(scope)
 		if err != nil {
 			return fmt.Errorf("failed to read list of nodes: %w", err)
 		}

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -116,6 +116,76 @@ func TestAlternatorLiveNodes_ClusterScopeMergesSeedNodes(t *testing.T) {
 	}
 }
 
+func TestAlternatorLiveNodes_CheckIfRackAndDatacenterSetCorrectlyRetriesSeedNodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		scope rt.Scope
+		query string
+	}{
+		{
+			name:  "datacenter",
+			scope: rt.NewDCScope("dc1", nil),
+			query: "dc=dc1",
+		},
+		{
+			name:  "rack",
+			scope: rt.NewRackScope("dc1", "rack1", nil),
+			query: "dc=dc1&rack=rack1",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var targetRequests atomic.Int32
+
+			aln, err := NewAlternatorLiveNodes(
+				[]string{"dc1-node.local", "dc2-node.local"},
+				WithALNPort(8080),
+				WithALNRoutingScope(tt.scope),
+				WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+					return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+						if req.URL.Path == "" || req.URL.Path == "/" {
+							return resp.HealthCheckResponse(req)
+						}
+						if req.URL.Path != "/localnodes" {
+							t.Fatalf("unexpected request path %q", req.URL.Path)
+						}
+						if req.URL.RawQuery != tt.query {
+							t.Fatalf("unexpected /localnodes query %q, want %q", req.URL.RawQuery, tt.query)
+						}
+						switch req.URL.Hostname() {
+						case "dc1-node.local":
+							targetRequests.Add(1)
+							return resp.AlternatorNodesResponse([]string{"dc1-node.local"}, req)
+						case "dc2-node.local":
+							return resp.AlternatorNodesResponse(nil, req)
+						default:
+							t.Fatalf("unexpected validation host %q", req.URL.Hostname())
+							return nil, nil
+						}
+					})
+				}),
+			)
+			if err != nil {
+				t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+			}
+			defer aln.Stop()
+
+			if err := aln.CheckIfRackAndDatacenterSetCorrectly(); err != nil {
+				t.Fatalf("CheckIfRackAndDatacenterSetCorrectly returned error: %v", err)
+			}
+			if targetRequests.Load() == 0 {
+				t.Fatalf("expected validation request for target seed")
+			}
+		})
+	}
+}
+
 type liveNodesRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f liveNodesRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary
- reuse the all-seed `/localnodes` lookup for `CheckIfRackAndDatacenterSetCorrectly`
- avoid false validation failures when the first contacted seed is outside the requested DC/rack
- add regression coverage for DC and rack validation with one wrong-DC seed and one target seed

## Testing
- `make test-unit`
- `make check-golangci`

Fixes #121