### PR TITLE
Document AWS region behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ func main() {
 
 ### Customizing AWS SDK config
 
+#### AWS region
+
+The helpers set the AWS SDK region to `default-alb-region` by default. The AWS SDK requires a region and includes it in
+request signing, logs, tracing, and other SDK-visible configuration. Alternator does not use AWS regional endpoints and
+does not validate the signing region, so the default is only a placeholder that lets the client work without AWS-specific
+configuration.
+
+If your application, tracing, logging, metrics, or debugging tools inspect the AWS region, set it explicitly to the real
+deployment region or another value that is meaningful in your environment:
+
+```go
+h, _ := helper.NewHelper(
+    []string{"x.x.x.x"},
+    helper.WithAWSRegion("us-east-1"),
+)
+```
+
 Use `WithAWSConfigOptions` to tweak the generated `aws.Config` before building the DynamoDB client (e.g., adjust retryers or log mode). For AWS SDK v2:
 ```go
 h, _ := helper.NewHelper(

--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -74,8 +74,8 @@ var (
 	// WithRoutingScope makes DynamoDB client target only nodes from particular scope (dc, rack, cluster)
 	WithRoutingScope = shared.WithRoutingScope
 
-	// WithAWSRegion inject region into DynamoDB client, this region does not play any role
-	// One way you can use it - to have this region in the logs, CloudWatch.
+	// WithAWSRegion sets the AWS SDK region used for request signing and SDK-visible metadata.
+	// Alternator does not validate this region, but logs, tracing, metrics, and debugging tools may inspect it.
 	WithAWSRegion = shared.WithAWSRegion
 
 	// WithLogger sets logger

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -82,8 +82,8 @@ var (
 	// WithRoutingScope makes DynamoDB client target only nodes from particular scope (dc, rack, cluster)
 	WithRoutingScope = shared.WithRoutingScope
 
-	// WithAWSRegion inject region into DynamoDB client, this region does not play any role
-	// One way you can use it - to have this region in the logs, CloudWatch.
+	// WithAWSRegion sets the AWS SDK region used for request signing and SDK-visible metadata.
+	// Alternator does not validate this region, but logs, tracing, metrics, and debugging tools may inspect it.
 	WithAWSRegion = shared.WithAWSRegion
 
 	// WithLogger sets logger

--- a/shared/config.go
+++ b/shared/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Datacenter string
 	// RoutingScope is a scope of alternator nodes to target
 	RoutingScope rt.Scope
-	// AWSRegion a region that will be handed over to AWS SDK to forge requests
+	// AWSRegion is handed to the AWS SDK for request signing and SDK-visible metadata.
 	AWSRegion string
 	// AccessKeyID from AWS credentials
 	AccessKeyID string
@@ -254,8 +254,8 @@ func WithRoutingScope(routingScope rt.Scope) Option {
 	}
 }
 
-// WithAWSRegion inject region into DynamoDB client, this region does not play any role
-// One way you can use it - to have this region in the logs, CloudWatch.
+// WithAWSRegion sets the AWS SDK region used for request signing and SDK-visible metadata.
+// Alternator does not validate this region, but logs, tracing, metrics, and debugging tools may inspect it.
 func WithAWSRegion(region string) Option {
 	return func(config *Config) {
 		config.AWSRegion = region


### PR DESCRIPTION
## Summary
- document why the helper defaults the AWS SDK region to `default-alb-region`
- explain that Alternator does not validate the signing region, but SDK logs, tracing, metrics, and debugging tools may inspect it
- point users to `WithAWSRegion` for setting a meaningful deployment region

## Testing
- `make test-unit`
- `make check-golangci`

Fixes #106