### PR TITLE
Update CI action pins

### DIFF
--- a/.github/workflows/attach-project-to-issue.yml
+++ b/.github/workflows/attach-project-to-issue.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Add issue ${{ github.event.issue.number }} to Drivers-Team github project
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: 'https://github.com/orgs/scylladb/projects/71'
           github-token: ${{ secrets.GIT_PROJECT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Checkout target tag
         if: ${{ inputs.target-tag != '' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.target-tag }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install GoLang
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.work"
           cache-dependency-path: "**/go.sum"


### PR DESCRIPTION
## Summary
- update `actions/checkout` pins to v6.0.3
- update `actions/setup-go` pin to v6.5.0
- update `actions/add-to-project` pin to v2.0.0, replacing the blocked stale Renovate update while keeping the same workflow inputs

## Testing
- `make build`
- `make check-golangci`
- `make test-unit`
- `make test-integration`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "yaml ok"' .github/workflows/tests.yml .github/workflows/release.yml .github/workflows/attach-project-to-issue.yml`
- `git diff --check`

Note: `actionlint` is not installed in this environment.