### PR TITLE
Return node health status snapshots

### DIFF
--- a/shared/nodeshealth/node_health.go
+++ b/shared/nodeshealth/node_health.go
@@ -267,12 +267,16 @@ func (e *NodeHealthStore) TryReleaseQuarantinedNodes() []url.URL {
 	return released
 }
 
-// GetNodeStatus retrieves the health status of the given node if present.
+// GetNodeStatus retrieves a snapshot of the health status of the given node if present.
 func (e *NodeHealthStore) GetNodeStatus(node url.URL) *NodeHealthStatus {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	status := e.nodesStatuses[node]
-	return status
+	if status == nil {
+		return nil
+	}
+	snapshot := *status
+	return &snapshot
 }
 
 // ReleaseNode released node from quarantine

--- a/shared/nodeshealth/node_health_test.go
+++ b/shared/nodeshealth/node_health_test.go
@@ -72,6 +72,38 @@ func TestNodeHealthStoreScoreAdjustments(t *testing.T) {
 	}
 }
 
+func TestNodeHealthStoreGetNodeStatusReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	node := url.URL{Scheme: "http", Host: "node-snapshot:8080"}
+	store, err := NewNodeHealthStoreBasic(DefaultNodeHealthStoreConfig(), nil, []url.URL{node})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status := store.GetNodeStatus(node)
+	if status == nil {
+		t.Fatalf("expected status for %v", node)
+	}
+	status.score = 999
+	status.quarantined = false
+	status.updated = time.Time{}
+
+	after := store.GetNodeStatus(node)
+	if after == nil {
+		t.Fatalf("expected status for %v", node)
+	}
+	if after.Score() != 0 {
+		t.Fatalf("expected stored score to stay unchanged, got %d", after.Score())
+	}
+	if !after.Quarantined() {
+		t.Fatalf("expected stored quarantine status to stay unchanged")
+	}
+	if after.Updated().IsZero() {
+		t.Fatalf("expected stored update timestamp to stay unchanged")
+	}
+}
+
 func TestNodeHealthStoreResetsScoreAfterInterval(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`NodeHealthStore.GetNodeStatus` returned the internal `*NodeHealthStatus` stored in the map after releasing the store lock. Callers could mutate that pointer and race with internal health updates or accidentally change the store state.

This change makes `GetNodeStatus` return a copied snapshot while preserving the existing pointer-returning API shape. It also switches the method to an `RLock` and adds a regression test that verifies mutations to the returned status do not affect the store.

## Tests

- `go test ./...` in `shared`
- `go test ./...` in `sdkv1`
- `go test ./...` in `sdkv2`