### PR TITLE
Route BatchWriteItem tied votes deterministically

### DIFF
--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -35,6 +35,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime/debug"
+	"sort"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -701,6 +702,7 @@ func (lb *Helper) batchWriteQueryPlan(requestItems map[string][]types.WriteReque
 	}
 
 	votes := make(map[url.URL]int)
+	hashes := make([]int64, 0, len(candidates))
 	discoveryTriggered := make(map[string]struct{})
 	for _, candidate := range candidates {
 		keyName := lb.keyAffinity.GetPartitionKeyName(candidate.tableName)
@@ -724,6 +726,7 @@ func (lb *Helper) batchWriteQueryPlan(requestItems map[string][]types.WriteReque
 		if err != nil {
 			continue
 		}
+		hashes = append(hashes, hash)
 
 		node := shared.FirstNodeWithSeed(activeNodes, hash)
 		if node.Host != "" {
@@ -731,12 +734,12 @@ func (lb *Helper) batchWriteQueryPlan(requestItems map[string][]types.WriteReque
 		}
 	}
 
-	preferredNode, ok := selectBatchWritePreferredNode(votes)
-	if !ok {
-		return nil, fmt.Errorf("batch write request does not have a unique preferred node")
+	preferredNodes := selectBatchWritePreferredNodes(votes)
+	if len(preferredNodes) == 0 {
+		return nil, fmt.Errorf("batch write request does not have usable preferred nodes")
 	}
 
-	return shared.NewLazyQueryPlanWithPreferredNode(lb.nodes, preferredNode), nil
+	return shared.NewLazyQueryPlanWithPreferredNodes(lb.nodes, preferredNodes, batchWriteSeed(hashes)), nil
 }
 
 func selectBatchWriteRoutingCandidates(requestItems map[string][]types.WriteRequest) []batchWriteRoutingCandidate {
@@ -765,25 +768,41 @@ func selectBatchWriteRoutingCandidates(requestItems map[string][]types.WriteRequ
 	return candidates
 }
 
-func selectBatchWritePreferredNode(votes map[url.URL]int) (url.URL, bool) {
-	var preferredNode url.URL
-	var preferredVotes int
-	var tied bool
+func selectBatchWritePreferredNodes(votes map[url.URL]int) []url.URL {
+	if len(votes) == 0 {
+		return nil
+	}
+
+	preferredNodes := make([]url.URL, 0, len(votes))
 	for node, count := range votes {
-		switch {
-		case count > preferredVotes:
-			preferredNode = node
-			preferredVotes = count
-			tied = false
-		case count == preferredVotes:
-			tied = true
+		if count > 0 {
+			preferredNodes = append(preferredNodes, node)
 		}
 	}
 
-	if preferredVotes == 0 || tied {
-		return url.URL{}, false
+	sort.Slice(preferredNodes, func(i, j int) bool {
+		left := preferredNodes[i]
+		right := preferredNodes[j]
+		if votes[left] != votes[right] {
+			return votes[left] > votes[right]
+		}
+		return left.String() < right.String()
+	})
+
+	return preferredNodes
+}
+
+func batchWriteSeed(hashes []int64) int64 {
+	sortedHashes := append([]int64(nil), hashes...)
+	sort.Slice(sortedHashes, func(i, j int) bool {
+		return sortedHashes[i] < sortedHashes[j]
+	})
+
+	var seed int64
+	for _, hash := range sortedHashes {
+		seed = seed*31 + hash
 	}
-	return preferredNode, true
+	return seed
 }
 
 type keyAffinity struct {

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -1538,7 +1539,11 @@ func TestBatchWriteItemKeyRouteAffinityVotingSelectsPreferredNode(t *testing.T) 
 	}
 
 	got := mustBatchWritePlanNodes(t, h, input, len(batchWriteTestNodes()))
-	want := append([]string{target.Host}, batchWriteSortedTestNodeHostsExcept(target)...)
+	want := batchWriteExpectedPlanHosts(t, []url.URL{target, other}, []string{
+		targetKeys[0],
+		otherKey,
+		targetKeys[1],
+	})
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("unexpected batch write query plan (-want +got):\n%s", diff)
 	}
@@ -1578,6 +1583,49 @@ func TestBatchWriteItemKeyRouteAffinityVotingDeleteMajoritySelectsPreferredNode(
 	node := mustBatchWriteFirstNode(t, h, input)
 	if node != target {
 		t.Fatalf("expected delete majority to select %s, got %s", target.Host, node.Host)
+	}
+}
+
+func TestBatchWriteItemKeyRouteAffinityVotingOrdersAllVotedNodesBeforeUnvoted(t *testing.T) {
+	t.Parallel()
+
+	sortedNodes := batchWriteSortedTestNodes()
+	target := sortedNodes[3]
+	other := sortedNodes[2]
+	targetKeys := batchWriteStringKeysForNode(t, target, 2)
+	otherKey := batchWriteStringKeysForNode(t, other, 1)[0]
+
+	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
+	input := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			"orders": {
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(targetKeys[0], "target-a"),
+					},
+				},
+				{
+					DeleteRequest: &types.DeleteRequest{
+						Key: keyWithID(otherKey),
+					},
+				},
+				{
+					PutRequest: &types.PutRequest{
+						Item: itemWithID(targetKeys[1], "target-b"),
+					},
+				},
+			},
+		},
+	}
+
+	got := mustBatchWritePlanNodes(t, h, input, len(batchWriteTestNodes()))
+	want := batchWriteExpectedPlanHosts(t, []url.URL{target, other}, []string{
+		targetKeys[0],
+		otherKey,
+		targetKeys[1],
+	})
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected batch write query plan (-want +got):\n%s", diff)
 	}
 }
 
@@ -1640,22 +1688,24 @@ func TestBatchWriteItemKeyRouteAffinityVotingStableForEquivalentBatches(t *testi
 		},
 	}
 
-	firstNode := mustBatchWriteFirstNode(t, h, first)
-	secondNode := mustBatchWriteFirstNode(t, h, second)
-	if firstNode != target {
-		t.Fatalf("expected first request to select %s, got %s", target.Host, firstNode.Host)
+	firstNodes := mustBatchWritePlanNodes(t, h, first, len(batchWriteTestNodes()))
+	secondNodes := mustBatchWritePlanNodes(t, h, second, len(batchWriteTestNodes()))
+	if firstNodes[0] != target.Host {
+		t.Fatalf("expected first request to select %s, got %s", target.Host, firstNodes[0])
 	}
-	if secondNode != firstNode {
-		t.Fatalf("expected equivalent reordered request to select %s, got %s", firstNode.Host, secondNode.Host)
+	if diff := cmp.Diff(firstNodes, secondNodes); diff != "" {
+		t.Fatalf("expected equivalent reordered requests to use the same query plan (-want +got):\n%s", diff)
 	}
 }
 
-func TestBatchWriteItemKeyRouteAffinityVotingFallsBackOnTie(t *testing.T) {
+func TestBatchWriteItemKeyRouteAffinityVotingUsesDeterministicTieBreak(t *testing.T) {
 	t.Parallel()
 
 	nodes := batchWriteSortedTestNodes()
-	leftKey := batchWriteStringKeysForNode(t, nodes[0], 1)[0]
-	rightKey := batchWriteStringKeysForNode(t, nodes[1], 1)[0]
+	left := nodes[3]
+	right := nodes[2]
+	leftKey := batchWriteStringKeysForNode(t, left, 1)[0]
+	rightKey := batchWriteStringKeysForNode(t, right, 1)[0]
 
 	h := newBatchWriteAffinityTestHelper(map[string]string{"orders": "id"})
 	input := &dynamodb.BatchWriteItemInput{
@@ -1675,8 +1725,13 @@ func TestBatchWriteItemKeyRouteAffinityVotingFallsBackOnTie(t *testing.T) {
 		},
 	}
 
-	if _, err := h.batchWriteQueryPlan(input.RequestItems); err == nil {
-		t.Fatal("expected tied top vote count to fall back to non-affinity routing")
+	got := mustBatchWritePlanNodes(t, h, input, len(batchWriteTestNodes()))
+	want := batchWriteExpectedPlanHosts(t, []url.URL{right, left}, []string{
+		leftKey,
+		rightKey,
+	})
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected batch write tie-break query plan (-want +got):\n%s", diff)
 	}
 }
 
@@ -1971,15 +2026,43 @@ func batchWriteSortedTestNodes() []url.URL {
 	return nodes
 }
 
-func batchWriteSortedTestNodeHostsExcept(except url.URL) []string {
+func batchWriteExpectedPlanHosts(t *testing.T, preferred []url.URL, keys []string) []string {
+	t.Helper()
+
+	hashes := make([]int64, 0, len(keys))
+	for _, key := range keys {
+		hashes = append(hashes, batchWriteHashForStringKey(t, key))
+	}
+
 	nodes := batchWriteSortedTestNodes()
-	hosts := make([]string, 0, len(nodes)-1)
-	for _, node := range nodes {
-		if node != except {
-			hosts = append(hosts, node.Host)
+	hosts := make([]string, 0, len(nodes))
+	for _, preferredNode := range preferred {
+		idx := slices.Index(nodes, preferredNode)
+		if idx < 0 {
+			continue
 		}
+		hosts = append(hosts, nodes[idx].Host)
+		nodes = append(nodes[:idx], nodes[idx+1:]...)
+	}
+
+	rnd := rand.New(rand.NewSource(batchWriteSeed(hashes)))
+	for len(nodes) > 0 {
+		idx := rnd.Intn(len(nodes))
+		hosts = append(hosts, nodes[idx].Host)
+		nodes[idx] = nodes[len(nodes)-1]
+		nodes = nodes[:len(nodes)-1]
 	}
 	return hosts
+}
+
+func batchWriteHashForStringKey(t *testing.T, key string) int64 {
+	t.Helper()
+
+	hash, err := HashAttributeValue(&types.AttributeValueMemberS{Value: key})
+	if err != nil {
+		t.Fatalf("HashAttributeValue returned error: %v", err)
+	}
+	return hash
 }
 
 func sortNodes(nodes []url.URL) []url.URL {

--- a/shared/query_plan.go
+++ b/shared/query_plan.go
@@ -16,14 +16,12 @@ type nodesSource interface {
 // It defers fetching active and quarantined nodes from the source until the first
 // time they are needed by Next().
 type LazyQueryPlan struct {
-	nodes              nodesSource
-	activeNodes        []url.URL
-	quarantinedNodes   []url.URL
-	rnd                *rand.Rand
-	preferredNode      url.URL
-	hasPreferredNode   bool
-	deterministicOrder bool
-	sortNodes          bool
+	nodes            nodesSource
+	activeNodes      []url.URL
+	quarantinedNodes []url.URL
+	rnd              *rand.Rand
+	preferredNodes   []url.URL
+	sortNodes        bool
 }
 
 // NewLazyQueryPlan constructs a plan bound to the provided nodes source.
@@ -52,17 +50,15 @@ func NewLazyQueryPlanWithSortedSeed(nodes nodesSource, seed int64) *LazyQueryPla
 	}
 }
 
-// NewLazyQueryPlanWithPreferredNode constructs a deterministic plan that tries
-// preferredNode first when it is still active, then the remaining nodes in
-// lexicographic address order.
-func NewLazyQueryPlanWithPreferredNode(nodes nodesSource, preferredNode url.URL) *LazyQueryPlan {
+// NewLazyQueryPlanWithPreferredNodes constructs a seeded plan that tries
+// preferredNodes first when they are still active, then applies the seeded
+// selection algorithm to the remaining lexicographically sorted nodes.
+func NewLazyQueryPlanWithPreferredNodes(nodes nodesSource, preferredNodes []url.URL, seed int64) *LazyQueryPlan {
 	return &LazyQueryPlan{
-		nodes:              nodes,
-		rnd:                rand.New(rand.NewSource(0)),
-		preferredNode:      preferredNode,
-		hasPreferredNode:   preferredNode.Host != "",
-		deterministicOrder: true,
-		sortNodes:          true,
+		nodes:          nodes,
+		rnd:            rand.New(rand.NewSource(seed)),
+		preferredNodes: append([]url.URL(nil), preferredNodes...),
+		sortNodes:      true,
 	}
 }
 
@@ -83,9 +79,13 @@ func (p *LazyQueryPlan) Next() url.URL {
 	if p.activeNodes == nil {
 		p.activeNodes = p.prepareNodes(p.nodes.GetActiveNodes())
 	}
-	if p.hasPreferredNode {
-		p.hasPreferredNode = false
-		if node, ok := popNode(&p.activeNodes, p.preferredNode); ok {
+	for len(p.preferredNodes) > 0 {
+		preferredNode := p.preferredNodes[0]
+		p.preferredNodes = p.preferredNodes[1:]
+		if preferredNode.Host == "" {
+			continue
+		}
+		if node, ok := popNode(&p.activeNodes, preferredNode); ok {
 			return node
 		}
 	}
@@ -104,12 +104,6 @@ func (p *LazyQueryPlan) Next() url.URL {
 }
 
 func (p *LazyQueryPlan) pickAndRemove(nodes *[]url.URL) url.URL {
-	if p.deterministicOrder {
-		node := (*nodes)[0]
-		*nodes = (*nodes)[1:]
-		return node
-	}
-
 	idx := p.rnd.Intn(len(*nodes))
 	node := (*nodes)[idx]
 	(*nodes)[idx] = (*nodes)[len(*nodes)-1]

--- a/shared/query_plan_unit_test.go
+++ b/shared/query_plan_unit_test.go
@@ -123,14 +123,15 @@ func TestLazyQueryPlan(t *testing.T) {
 		}
 	})
 
-	t.Run("PreferredNodeFirstThenSortedRemaining", func(t *testing.T) {
+	t.Run("PreferredNodesSinglePreferredFirstThenSeededRemaining", func(t *testing.T) {
+		const seed = int64(42)
 		preferred := url.URL{Host: "b"}
 		source := &fakeNodesSource{
 			activeNodes:      []url.URL{{Host: "c"}, preferred, {Host: "a"}},
 			quarantinedNodes: []url.URL{{Host: "q2"}, {Host: "q1"}},
 		}
 
-		plan := NewLazyQueryPlanWithPreferredNode(source, preferred)
+		plan := NewLazyQueryPlanWithPreferredNodes(source, []url.URL{preferred}, seed)
 		got := []string{
 			plan.Next().Host,
 			plan.Next().Host,
@@ -138,7 +139,7 @@ func TestLazyQueryPlan(t *testing.T) {
 			plan.Next().Host,
 			plan.Next().Host,
 		}
-		want := []string{"b", "a", "c", "q1", "q2"}
+		want := expectedPreferredPlanHosts(source.activeNodes, source.quarantinedNodes, []url.URL{preferred}, seed)
 		for i := range got {
 			if got[i] != want[i] {
 				t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
@@ -146,24 +147,87 @@ func TestLazyQueryPlan(t *testing.T) {
 		}
 	})
 
-	t.Run("PreferredNodeMissingUsesSortedActiveNodes", func(t *testing.T) {
+	t.Run("PreferredNodesFirstThenSeededRemaining", func(t *testing.T) {
+		const seed = int64(42)
+		preferredC := url.URL{Host: "c"}
+		preferredB := url.URL{Host: "b"}
+		source := &fakeNodesSource{
+			activeNodes:      []url.URL{{Host: "d"}, {Host: "a"}, preferredB, preferredC},
+			quarantinedNodes: []url.URL{{Host: "q2"}, {Host: "q1"}},
+		}
+
+		plan := NewLazyQueryPlanWithPreferredNodes(source, []url.URL{preferredC, preferredB}, seed)
+		got := []string{
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+			plan.Next().Host,
+		}
+		want := expectedPreferredPlanHosts(
+			source.activeNodes,
+			source.quarantinedNodes,
+			[]url.URL{preferredC, preferredB},
+			seed,
+		)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
+			}
+		}
+	})
+
+	t.Run("PreferredNodesMissingUsesSortedActiveNodes", func(t *testing.T) {
+		const seed = int64(42)
 		source := &fakeNodesSource{
 			activeNodes: []url.URL{{Host: "c"}, {Host: "a"}, {Host: "b"}},
 		}
 
-		plan := NewLazyQueryPlanWithPreferredNode(source, url.URL{Host: "missing"})
+		plan := NewLazyQueryPlanWithPreferredNodes(source, []url.URL{{Host: "missing"}}, seed)
 		got := []string{
 			plan.Next().Host,
 			plan.Next().Host,
 			plan.Next().Host,
 		}
-		want := []string{"a", "b", "c"}
+		want := expectedPreferredPlanHosts(source.activeNodes, nil, []url.URL{{Host: "missing"}}, seed)
 		for i := range got {
 			if got[i] != want[i] {
 				t.Fatalf("unexpected order at %d: got %v, want %v", i, got, want)
 			}
 		}
 	})
+}
+
+func expectedPreferredPlanHosts(activeNodes, quarantinedNodes, preferredNodes []url.URL, seed int64) []string {
+	rnd := rand.New(rand.NewSource(seed))
+	activeNodes = cloneAndSortNodes(activeNodes)
+	quarantinedNodes = cloneAndSortNodes(quarantinedNodes)
+
+	hosts := make([]string, 0, len(activeNodes)+len(quarantinedNodes))
+	for _, preferred := range preferredNodes {
+		if preferred.Host == "" {
+			continue
+		}
+		if node, ok := popNode(&activeNodes, preferred); ok {
+			hosts = append(hosts, node.Host)
+		}
+	}
+
+	hosts = append(hosts, seededPlanHosts(rnd, activeNodes)...)
+	hosts = append(hosts, seededPlanHosts(rnd, quarantinedNodes)...)
+	return hosts
+}
+
+func seededPlanHosts(rnd *rand.Rand, nodes []url.URL) []string {
+	hosts := make([]string, 0, len(nodes))
+	for len(nodes) > 0 {
+		idx := rnd.Intn(len(nodes))
+		hosts = append(hosts, nodes[idx].Host)
+		nodes[idx] = nodes[len(nodes)-1]
+		nodes = nodes[:len(nodes)-1]
+	}
+	return hosts
 }
 
 func TestFirstNodeWithSeedUsesSortedNodeAddresses(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR changes BatchWriteItem key-route affinity so tied or multi-node vote results still produce a deterministic affinity query plan instead of falling back to normal routing. Preferred voted coordinators are tried first, and the remaining nodes are selected with a stable seed derived from the batch keys.

## Problem

BatchWriteItem under KeyRouteAffinityAnyWrite extracts usable partition-key candidates from PutRequest.Item and DeleteRequest.Key, hashes each key, and counts which coordinator each item would prefer. The previous implementation only accepted the result when exactly one node had a unique highest vote count.

That meant a batch like this lost affinity entirely:

- item A votes for node-1
- item B votes for node-2

Both votes are valid affinity signals, but the tie was treated as if no routing target existed. The request then fell back to regular routing and could be sent to a node that none of the batch items preferred.

The previous implementation also kept only one preferred node. For a batch with a majority and minority vote, retry order did not preserve the other voted coordinator ahead of unrelated nodes.

## What This Solves

This PR makes BatchWriteItem affinity use all usable votes:

- count votes per preferred coordinator
- sort voted coordinators by descending vote count
- break equal vote counts deterministically by node URL
- try all voted coordinators first
- derive a stable batch seed from all usable partition-key hashes
- use that seed for the remaining active nodes after voted coordinators are exhausted
- fall back only when there are no usable votes

This keeps routing deterministic while preserving as much batch-locality signal as the request provides. The remainder order is still seed-based instead of becoming a plain sorted tail.

## Implementation Details

- Adds shared.NewLazyQueryPlanWithPreferredNodes with an explicit seed argument.
- Removes the old single-preferred-node helper.
- Removes the previous deterministic-order branch from LazyQueryPlan; non-preferred nodes now use the existing seeded pick-and-remove path.
- Replaces BatchWriteItem unique-winner selection with vote-sorted preferred-node selection.
- Tracks successful BatchWriteItem partition-key hashes and derives an order-independent batch seed by sorting hashes before combining them.
- Updates BatchWriteItem tests so tied top votes now produce an affinity plan.
- Adds coverage that all voted nodes are tried before unvoted nodes.
- Adds coverage that equivalent reordered batches get the same full query plan.
- Adds shared query-plan coverage for preferred nodes followed by seeded remaining nodes.

## Testing

- go test -run 'TestLazyQueryPlan|TestBatchWriteItemKeyRouteAffinity' ./shared ./sdkv2
- make test-unit
- make check-golangci