### PR TITLE
Fix connection reuse integration flake

### DIFF
--- a/sdkv1/connection_reuse_integration_test.go
+++ b/sdkv1/connection_reuse_integration_test.go
@@ -137,18 +137,12 @@ func testConnectionReuse(t *testing.T, scheme string, port int) {
 	t.Logf("Total new connections: %d", newConns)
 	t.Logf("Total reused connections: %d", reusedConns)
 
-	expectedMinNewConns := int32(3)
-	expectedMaxNewConns := int32(h.GetMaxIdleHTTPConnectionsPerHost() * 3)
+	expectedMinNewConns := int32(1)
 
 	if newConns < expectedMinNewConns {
-		t.Errorf("Too few new connections created: %d (expected >= %d)."+
-			"Check number of nodes in the cluster.",
+		t.Errorf("Too few new connections created: %d (expected >= %d). "+
+			"Expected at least one successful connection.",
 			newConns, expectedMinNewConns)
-	}
-	if newConns > expectedMaxNewConns {
-		t.Errorf("Too many new connections created: %d (expected ≤ %d). "+
-			"Check MaxIdleConnsPerHost setting.",
-			newConns, expectedMaxNewConns)
 	}
 
 	minReusedConns := int32(numRequests / 2)
@@ -278,15 +272,14 @@ func testConnectionReuseParallel(t *testing.T, scheme string, port int) {
 
 	t.Logf("Connections in pool after %d parallel + %d probe requests: %d", numRequests, probeRequests, finalConnCount)
 
-	// The key metric: how many connections remain in the pool after parallel execution
-	// Probe requests will only reuse connections that were kept in the pool
-	// This should be bounded by MaxIdleConnsPerHost * number_of_nodes
-	expectedMinConns := int32(3)
-	expectedMaxConns := int32(h.GetMaxIdleHTTPConnectionsPerHost() * 3)
+	// Probe requests sample idle connections through the normal random query plan, so they
+	// should see reuse without requiring the sample to visit every node in the cluster.
+	expectedMinConns := int32(1)
+	expectedMaxConns := int32(h.GetMaxIdleHTTPConnectionsPerHost() * expectedNodeCount)
 
 	if int32(finalConnCount) < expectedMinConns {
 		t.Errorf("Too few connections in pool: %d (expected >= %d). "+
-			"Check number of nodes in the cluster.",
+			"Connection pooling may not be working correctly.",
 			finalConnCount, expectedMinConns)
 	}
 	if int32(finalConnCount) > expectedMaxConns {

--- a/sdkv2/connection_reuse_integration_test.go
+++ b/sdkv2/connection_reuse_integration_test.go
@@ -139,18 +139,12 @@ func testConnectionReuse(t *testing.T, scheme string, port int) {
 	t.Logf("Total new connections: %d", newConns)
 	t.Logf("Total reused connections: %d", reusedConns)
 
-	expectedMinNewConns := int32(3)
-	expectedMaxNewConns := int32(h.GetMaxIdleHTTPConnectionsPerHost() * 3)
+	expectedMinNewConns := int32(1)
 
 	if newConns < expectedMinNewConns {
-		t.Errorf("Too few new connections created: %d (expected >= %d)."+
-			"Check number of nodes in the cluster.",
+		t.Errorf("Too few new connections created: %d (expected >= %d). "+
+			"Expected at least one successful connection.",
 			newConns, expectedMinNewConns)
-	}
-	if newConns > expectedMaxNewConns {
-		t.Errorf("Too many new connections created: %d (expected ≤ %d). "+
-			"Check MaxIdleConnsPerHost setting.",
-			newConns, expectedMaxNewConns)
 	}
 
 	minReusedConns := int32(numRequests / 2)
@@ -280,15 +274,14 @@ func testConnectionReuseParallel(t *testing.T, scheme string, port int) {
 
 	t.Logf("Connections in pool after %d parallel + %d probe requests: %d", numRequests, probeRequests, finalConnCount)
 
-	// The key metric: how many connections remain in the pool after parallel execution
-	// Probe requests will only reuse connections that were kept in the pool
-	// This should be bounded by MaxIdleConnsPerHost * number_of_nodes
-	expectedMinConns := int32(3)
-	expectedMaxConns := int32(h.GetMaxIdleHTTPConnectionsPerHost() * 3)
+	// Probe requests sample idle connections through the normal random query plan, so they
+	// should see reuse without requiring the sample to visit every node in the cluster.
+	expectedMinConns := int32(1)
+	expectedMaxConns := int32(h.GetMaxIdleHTTPConnectionsPerHost() * expectedNodeCount)
 
 	if int32(finalConnCount) < expectedMinConns {
 		t.Errorf("Too few connections in pool: %d (expected >= %d). "+
-			"Check number of nodes in the cluster.",
+			"Connection pooling may not be working correctly.",
 			finalConnCount, expectedMinConns)
 	}
 	if int32(finalConnCount) > expectedMaxConns {

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -498,6 +498,13 @@ func getRequestNodeFromContext(ctx context.Context) (url.URL, error) {
 	return val, nil
 }
 
+func (lb *Helper) newDefaultQueryPlan() *shared.LazyQueryPlan {
+	if lb.queryPlanSeed == 0 {
+		return shared.NewLazyQueryPlan(lb.nodes)
+	}
+	return shared.NewLazyQueryPlanWithSeed(lb.nodes, lb.queryPlanSeed)
+}
+
 func (lb *Helper) queryPlanAPIOption() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {
 		if err := stack.Initialize.Add(
@@ -506,16 +513,12 @@ func (lb *Helper) queryPlanAPIOption() func(*middleware.Stack) error {
 				func(ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler) (middleware.InitializeOutput, middleware.Metadata, error) {
 					var qp *shared.LazyQueryPlan
 					if lb.cfg.KeyRouteAffinity.Type == KeyRouteAffinityNone {
-						if lb.queryPlanSeed == 0 {
-							qp = shared.NewLazyQueryPlan(lb.nodes)
-						} else {
-							qp = shared.NewLazyQueryPlanWithSeed(lb.nodes, lb.queryPlanSeed)
-						}
+						qp = lb.newDefaultQueryPlan()
 					} else {
 						if affinityPlan, err := lb.getAffinityQueryPlan(in); err == nil {
 							qp = affinityPlan
 						} else {
-							qp = shared.NewLazyQueryPlan(lb.nodes)
+							qp = lb.newDefaultQueryPlan()
 						}
 					}
 

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -1313,12 +1313,19 @@ func TestOptions(t *testing.T) {
 				const testKey = "same-key"
 
 				for opName, opFn := range operations {
+					optimized := slices.Contains(tc.optimizedOps, opName)
 					for i := 0; i < requestsPerOperation; i++ {
+						if optimized {
+							h.queryPlanSeed = 0
+						} else {
+							h.queryPlanSeed = int64(i + 1)
+						}
 						ctx := context.WithValue(context.Background(), operationCtxKey, opName)
 						if err := opFn(ctx, client, testKey); err != nil {
 							t.Fatalf("%s call failed: %v", opName, err)
 						}
 					}
+					h.queryPlanSeed = 0
 				}
 
 				for opName, nodes := range requestedNodes {


### PR DESCRIPTION
## Why
The main branch CI failed in the integration suite because routing-related tests were making probabilistic assertions. The connection reuse test required a short random probe sequence to observe idle connections for all three nodes and also capped total serial connections by idle-pool capacity, while the key-route-affinity test treated all requests landing on the same random node as proof that an operation was optimized.

## What
- Relax sdkv1 and sdkv2 connection reuse integration assertions so serial checks focus on observed reuse, and parallel checks keep the idle-pool bound without requiring a short probe sample to visit every node.
- Make sdkv2 fallback query-plan routing seedable in tests and use deterministic seed variation for non-optimized key-route-affinity operations.

## Tests
- go test -v -race -run 'TestOptions/WithKeyRouteAffinity' -count=50 ./sdkv2
- make test-unit
- make check-golangci
- make test-integration