### PR TITLE
Keep connections reusable after non-200 responses

### DIFF
--- a/sdkv1/helper_unit_test.go
+++ b/sdkv1/helper_unit_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -460,4 +462,96 @@ func TestOptions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestDynamoDBNonOKResponsesKeepConnectionReusable(t *testing.T) {
+	t.Parallel()
+
+	server, connections, requests := newDynamoDBCountingHTTPServer(t)
+	defer server.Close()
+	host, port := splitTestServerHostPort(t, server)
+
+	h, err := NewHelper(
+		[]string{host},
+		WithPort(port),
+		WithCredentials("whatever", "secret"),
+		WithNodesListUpdatePeriod(0),
+		WithIdleNodesListUpdatePeriod(-1),
+		WithMaxIdleHTTPConnectionsPerHost(1),
+		WithAWSConfigOptions(func(cfg *aws.Config) {
+			cfg.MaxRetries = aws.Int(0)
+			cfg.SleepDelay = func(time.Duration) {}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer h.Stop()
+
+	ddb, err := h.NewDynamoDB()
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+
+	if _, err := ddb.ListTables(&dynamodb.ListTablesInput{}); err == nil {
+		t.Fatalf("expected first ListTables to fail")
+	}
+	if _, err := ddb.ListTables(&dynamodb.ListTablesInput{}); err == nil {
+		t.Fatalf("expected second ListTables to fail")
+	}
+	if _, err := ddb.ListTables(&dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("third ListTables returned error: %v", err)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("expected 3 DynamoDB requests, got %d", got)
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("expected non-200 DynamoDB responses to leave connection reusable, got %d connections", got)
+	}
+}
+
+func newDynamoDBCountingHTTPServer(t *testing.T) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+
+	var connections atomic.Int32
+	var requests atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		if r.Body != nil {
+			_, _ = io.Copy(io.Discard, r.Body)
+			_ = r.Body.Close()
+		}
+
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		switch requests.Add(1) {
+		case 1, 2:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"__type":"ValidationException","message":"bad"}`))
+		default:
+			_, _ = w.Write([]byte(`{"TableNames":[]}`))
+		}
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	return server, &connections, &requests
+}
+
+func splitTestServerHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+
+	host, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split server address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse server port: %v", err)
+	}
+	return host, port
 }

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"slices"
 	"sort"
@@ -1364,6 +1365,99 @@ func TestOptions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestDynamoDBNonOKResponsesKeepConnectionReusable(t *testing.T) {
+	t.Parallel()
+
+	server, connections, requests := newDynamoDBCountingHTTPServer(t)
+	defer server.Close()
+	host, port := splitTestServerHostPort(t, server)
+
+	h, err := NewHelper(
+		[]string{host},
+		WithPort(port),
+		WithCredentials("whatever", "secret"),
+		WithNodesListUpdatePeriod(0),
+		WithIdleNodesListUpdatePeriod(-1),
+		WithMaxIdleHTTPConnectionsPerHost(1),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer h.Stop()
+
+	ddb, err := h.NewDynamoDB(func(options *dynamodb.Options) {
+		options.Retryer = retry.NewStandard(func(options *retry.StandardOptions) {
+			options.MaxAttempts = 1
+			options.MaxBackoff = 0
+		})
+	})
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+
+	if _, err := ddb.ListTables(context.Background(), &dynamodb.ListTablesInput{}); err == nil {
+		t.Fatalf("expected first ListTables to fail")
+	}
+	if _, err := ddb.ListTables(context.Background(), &dynamodb.ListTablesInput{}); err == nil {
+		t.Fatalf("expected second ListTables to fail")
+	}
+	if _, err := ddb.ListTables(context.Background(), &dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("third ListTables returned error: %v", err)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("expected 3 DynamoDB requests, got %d", got)
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("expected non-200 DynamoDB responses to leave connection reusable, got %d connections", got)
+	}
+}
+
+func newDynamoDBCountingHTTPServer(t *testing.T) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+
+	var connections atomic.Int32
+	var requests atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		if r.Body != nil {
+			_, _ = io.Copy(io.Discard, r.Body)
+			_ = r.Body.Close()
+		}
+
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		switch requests.Add(1) {
+		case 1, 2:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"__type":"ValidationException","message":"bad"}`))
+		default:
+			_, _ = w.Write([]byte(`{"TableNames":[]}`))
+		}
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	return server, &connections, &requests
+}
+
+func splitTestServerHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+
+	host, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split server address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse server port: %v", err)
+	}
+	return host, port
 }
 
 func TestBatchWriteItemKeyRouteAffinityRoutingCandidates(t *testing.T) {

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -317,6 +317,7 @@ func NewAlternatorLiveNodes(initialNodes []string, options ...ALNOption) (*Alter
 				cfg.Logger.Error("failed to check node health status", logx.A("node", u.String()), logx.A("error", err))
 				return false
 			}
+			defer drainAndCloseResponseBody(resp.Body)
 			if resp.StatusCode != http.StatusOK {
 				cfg.Logger.Error("failed to check node health status, node reported an error",
 					logx.A("node", u.String()),
@@ -524,7 +525,7 @@ func (aln *AlternatorLiveNodes) getNodes(endpoint *url.URL) ([]url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint: errcheck // no need to check
+	defer drainAndCloseResponseBody(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("non-200 response")
 	}
@@ -548,6 +549,14 @@ func (aln *AlternatorLiveNodes) getNodes(endpoint *url.URL) ([]url.URL, error) {
 		uris = append(uris, *nodeURL)
 	}
 	return sortNodesByAddress(uris), nil
+}
+
+func drainAndCloseResponseBody(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
 }
 
 func sortNodesByAddress(nodes []url.URL) []url.URL {

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -1,12 +1,16 @@
 package shared
 
 import (
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"slices"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
 	"github.com/scylladb/alternator-client-golang/shared/rt"
 	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
 )
@@ -186,6 +190,89 @@ func TestAlternatorLiveNodes_CheckIfRackAndDatacenterSetCorrectlyRetriesSeedNode
 	}
 }
 
+func TestAlternatorLiveNodes_NonOKDiscoveryResponseKeepsConnectionReusable(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server, connections := newCountingHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/localnodes" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("temporary failure"))
+			return
+		}
+		_, _ = w.Write([]byte(`["127.0.0.1"]`))
+	}))
+	defer server.Close()
+
+	host, port := splitServerHostPort(t, server.URL)
+	aln, err := NewAlternatorLiveNodes(
+		[]string{host},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err == nil {
+		t.Fatalf("expected first UpdateLiveNodes to fail")
+	}
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("second UpdateLiveNodes returned error: %v", err)
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("expected non-200 discovery response to leave connection reusable, got %d connections", got)
+	}
+}
+
+func TestAlternatorLiveNodes_NonOKHealthResponseKeepsConnectionReusable(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server, connections := newCountingHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("temporary failure"))
+			return
+		}
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+
+	host, port := splitServerHostPort(t, server.URL)
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.QuarantineReleasePeriod = -1
+	aln, err := NewAlternatorLiveNodes(
+		[]string{host},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if released := aln.nodeHealthStore.TryReleaseQuarantinedNodes(); len(released) != 0 {
+		t.Fatalf("expected first health probe to keep node quarantined, released %v", released)
+	}
+	if released := aln.nodeHealthStore.TryReleaseQuarantinedNodes(); len(released) != 1 {
+		t.Fatalf("expected second health probe to release one node, released %v", released)
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("expected non-200 health response to leave connection reusable, got %d connections", got)
+	}
+}
+
 type liveNodesRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f liveNodesRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -198,4 +285,36 @@ func hostnames(nodes []url.URL) []string {
 		out = append(out, node.Hostname())
 	}
 	return out
+}
+
+func newCountingHTTPServer(t *testing.T, handler http.Handler) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+
+	var connections atomic.Int32
+	server := httptest.NewUnstartedServer(handler)
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	return server, &connections
+}
+
+func splitServerHostPort(t *testing.T, rawURL string) (string, int) {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	host, portString, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("failed to split server host: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse server port: %v", err)
+	}
+	return host, port
 }


### PR DESCRIPTION
Fixes #132

Drains and closes non-200 response bodies before returning errors from Alternator discovery and node-health probes, keeping Go HTTP transports eligible to reuse those sockets.

Adds repeated non-2xx keep-alive connection reuse coverage for:
- Alternator `/localnodes` discovery responses
- Alternator node health responses
- DynamoDB `ListTables` responses through both SDK v1 and SDK v2 helpers

Tests:
- `go test ./...` in `shared`
- `go test ./...` in `sdkv1`
- `go test ./...` in `sdkv2`