### PR TITLE
Use canonical BatchWriteItem retry order

### DIFF
--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -2127,13 +2126,8 @@ func batchWriteSortedTestNodes() []url.URL {
 	return nodes
 }
 
-func batchWriteExpectedPlanHosts(t *testing.T, preferred []url.URL, keys []string) []string {
+func batchWriteExpectedPlanHosts(t *testing.T, preferred []url.URL, _ []string) []string {
 	t.Helper()
-
-	hashes := make([]int64, 0, len(keys))
-	for _, key := range keys {
-		hashes = append(hashes, batchWriteHashForStringKey(t, key))
-	}
 
 	nodes := batchWriteSortedTestNodes()
 	hosts := make([]string, 0, len(nodes))
@@ -2146,24 +2140,10 @@ func batchWriteExpectedPlanHosts(t *testing.T, preferred []url.URL, keys []strin
 		nodes = append(nodes[:idx], nodes[idx+1:]...)
 	}
 
-	rnd := rand.New(rand.NewSource(batchWriteSeed(hashes)))
-	for len(nodes) > 0 {
-		idx := rnd.Intn(len(nodes))
-		hosts = append(hosts, nodes[idx].Host)
-		nodes[idx] = nodes[len(nodes)-1]
-		nodes = nodes[:len(nodes)-1]
+	for _, node := range nodes {
+		hosts = append(hosts, node.Host)
 	}
 	return hosts
-}
-
-func batchWriteHashForStringKey(t *testing.T, key string) int64 {
-	t.Helper()
-
-	hash, err := HashAttributeValue(&types.AttributeValueMemberS{Value: key})
-	if err != nil {
-		t.Fatalf("HashAttributeValue returned error: %v", err)
-	}
-	return hash
 }
 
 func sortNodes(nodes []url.URL) []url.URL {

--- a/shared/query_plan.go
+++ b/shared/query_plan.go
@@ -22,6 +22,7 @@ type LazyQueryPlan struct {
 	rnd              *rand.Rand
 	preferredNodes   []url.URL
 	sortNodes        bool
+	deterministic    bool
 }
 
 // NewLazyQueryPlan constructs a plan bound to the provided nodes source.
@@ -50,15 +51,16 @@ func NewLazyQueryPlanWithSortedSeed(nodes nodesSource, seed int64) *LazyQueryPla
 	}
 }
 
-// NewLazyQueryPlanWithPreferredNodes constructs a seeded plan that tries
-// preferredNodes first when they are still active, then applies the seeded
-// selection algorithm to the remaining lexicographically sorted nodes.
+// NewLazyQueryPlanWithPreferredNodes constructs a plan that tries
+// preferredNodes first when they are still active, then returns the remaining
+// lexicographically sorted nodes.
 func NewLazyQueryPlanWithPreferredNodes(nodes nodesSource, preferredNodes []url.URL, seed int64) *LazyQueryPlan {
+	_ = seed
 	return &LazyQueryPlan{
 		nodes:          nodes,
-		rnd:            rand.New(rand.NewSource(seed)),
 		preferredNodes: append([]url.URL(nil), preferredNodes...),
 		sortNodes:      true,
+		deterministic:  true,
 	}
 }
 
@@ -104,6 +106,12 @@ func (p *LazyQueryPlan) Next() url.URL {
 }
 
 func (p *LazyQueryPlan) pickAndRemove(nodes *[]url.URL) url.URL {
+	if p.deterministic {
+		node := (*nodes)[0]
+		*nodes = (*nodes)[1:]
+		return node
+	}
+
 	idx := p.rnd.Intn(len(*nodes))
 	node := (*nodes)[idx]
 	(*nodes)[idx] = (*nodes)[len(*nodes)-1]

--- a/shared/query_plan_unit_test.go
+++ b/shared/query_plan_unit_test.go
@@ -123,7 +123,7 @@ func TestLazyQueryPlan(t *testing.T) {
 		}
 	})
 
-	t.Run("PreferredNodesSinglePreferredFirstThenSeededRemaining", func(t *testing.T) {
+	t.Run("PreferredNodesSinglePreferredFirstThenSortedRemaining", func(t *testing.T) {
 		const seed = int64(42)
 		preferred := url.URL{Host: "b"}
 		source := &fakeNodesSource{
@@ -147,7 +147,7 @@ func TestLazyQueryPlan(t *testing.T) {
 		}
 	})
 
-	t.Run("PreferredNodesFirstThenSeededRemaining", func(t *testing.T) {
+	t.Run("PreferredNodesFirstThenSortedRemaining", func(t *testing.T) {
 		const seed = int64(42)
 		preferredC := url.URL{Host: "c"}
 		preferredB := url.URL{Host: "b"}
@@ -200,7 +200,7 @@ func TestLazyQueryPlan(t *testing.T) {
 }
 
 func expectedPreferredPlanHosts(activeNodes, quarantinedNodes, preferredNodes []url.URL, seed int64) []string {
-	rnd := rand.New(rand.NewSource(seed))
+	_ = seed
 	activeNodes = cloneAndSortNodes(activeNodes)
 	quarantinedNodes = cloneAndSortNodes(quarantinedNodes)
 
@@ -214,18 +214,15 @@ func expectedPreferredPlanHosts(activeNodes, quarantinedNodes, preferredNodes []
 		}
 	}
 
-	hosts = append(hosts, seededPlanHosts(rnd, activeNodes)...)
-	hosts = append(hosts, seededPlanHosts(rnd, quarantinedNodes)...)
+	hosts = append(hosts, planHosts(activeNodes)...)
+	hosts = append(hosts, planHosts(quarantinedNodes)...)
 	return hosts
 }
 
-func seededPlanHosts(rnd *rand.Rand, nodes []url.URL) []string {
+func planHosts(nodes []url.URL) []string {
 	hosts := make([]string, 0, len(nodes))
-	for len(nodes) > 0 {
-		idx := rnd.Intn(len(nodes))
-		hosts = append(hosts, nodes[idx].Host)
-		nodes[idx] = nodes[len(nodes)-1]
-		nodes = nodes[:len(nodes)-1]
+	for _, node := range nodes {
+		hosts = append(hosts, node.Host)
 	}
 	return hosts
 }


### PR DESCRIPTION
Fixes #101

Jira: https://scylladb.atlassian.net/browse/DRIVER-656
Epic: https://scylladb.atlassian.net/browse/DRIVER-653

Summary:
- Keep BatchWriteItem voted coordinators first.
- Return zero-vote active and quarantined coordinators in canonical address order after voted nodes.
- Leave seeded single-key affinity query plans unchanged.

Tests:
- go test ./shared ./sdkv2
- make check