### PR TITLE
test: cover DNS entrypoint discovery

### DIFF
--- a/sdkv1/helper_test.go
+++ b/sdkv1/helper_test.go
@@ -7,18 +7,24 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
 	helper "github.com/scylladb/alternator-client-golang/sdkv1"
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
 	"github.com/scylladb/alternator-client-golang/shared/rt"
 )
 
@@ -29,6 +35,69 @@ var (
 )
 
 var notFoundErr = new(*dynamodb.ResourceNotFoundException)
+
+func TestDNSEntrypointDiscoveryIntegration(t *testing.T) {
+	body := fetchIntegrationLocalNodes(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen on localhost: %v", err)
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/localnodes" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		_, _ = w.Write(body)
+	}))
+	server.Listener = listener
+	server.Start()
+	defer server.Close()
+
+	_, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split DNS entrypoint address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse DNS entrypoint port: %v", err)
+	}
+
+	h, err := helper.NewHelper(
+		[]string{"localhost"},
+		helper.WithPort(port),
+		helper.WithNodesListUpdatePeriod(0),
+		helper.WithIdleNodesListUpdatePeriod(0),
+		helper.WithNodeHealthStoreConfig(nodeshealth.NodeHealthStoreConfig{Disabled: true}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create alternator helper: %v", err)
+	}
+	defer h.Stop()
+
+	if err := h.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes() unexpectedly returned an error: %v", err)
+	}
+	if len(h.GetNodes()) == 0 {
+		t.Fatalf("UpdateLiveNodes() did not discover any nodes")
+	}
+}
+
+func fetchIntegrationLocalNodes(t *testing.T) []byte {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Get("http://" + knownNodes[0] + ":" + strconv.Itoa(httpPort) + "/localnodes")
+	if err != nil {
+		t.Fatalf("failed to fetch integration /localnodes: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("integration /localnodes returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("failed to read integration /localnodes: %v", err)
+	}
+	return body
+}
 
 func TestRoutingFallback(t *testing.T) {
 	h, err := helper.NewHelper(

--- a/sdkv2/helper_test.go
+++ b/sdkv2/helper_test.go
@@ -8,9 +8,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -20,6 +24,7 @@ import (
 	"github.com/aws/smithy-go"
 
 	"github.com/scylladb/alternator-client-golang/shared"
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
 	"github.com/scylladb/alternator-client-golang/shared/rt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -37,6 +42,69 @@ var (
 )
 
 var notFoundErr = new(*smithy.OperationError)
+
+func TestDNSEntrypointDiscoveryIntegration(t *testing.T) {
+	body := fetchIntegrationLocalNodes(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen on localhost: %v", err)
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/localnodes" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		_, _ = w.Write(body)
+	}))
+	server.Listener = listener
+	server.Start()
+	defer server.Close()
+
+	_, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split DNS entrypoint address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse DNS entrypoint port: %v", err)
+	}
+
+	h, err := helper.NewHelper(
+		[]string{"localhost"},
+		helper.WithPort(port),
+		helper.WithNodesListUpdatePeriod(0),
+		helper.WithIdleNodesListUpdatePeriod(0),
+		helper.WithNodeHealthStoreConfig(nodeshealth.NodeHealthStoreConfig{Disabled: true}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create alternator helper: %v", err)
+	}
+	defer h.Stop()
+
+	if err := h.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes() unexpectedly returned an error: %v", err)
+	}
+	if len(h.GetNodes()) == 0 {
+		t.Fatalf("UpdateLiveNodes() did not discover any nodes")
+	}
+}
+
+func fetchIntegrationLocalNodes(t *testing.T) []byte {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Get("http://" + knownNodes[0] + ":" + strconv.Itoa(httpPort) + "/localnodes")
+	if err != nil {
+		t.Fatalf("failed to fetch integration /localnodes: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("integration /localnodes returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("failed to read integration /localnodes: %v", err)
+	}
+	return body
+}
 
 func TestRoutingFallback(t *testing.T) {
 	h, err := helper.NewHelper(

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -117,6 +118,57 @@ func TestAlternatorLiveNodes_ClusterScopeMergesSeedNodes(t *testing.T) {
 	}
 	if dc2Requests.Load() == 0 {
 		t.Fatalf("expected discovery request for dc2 seed")
+	}
+}
+
+func TestAlternatorLiveNodes_DNSEntrypointDiscoversDNSNodeRecords(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen on localhost: %v", err)
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path != "/localnodes" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Host, "localhost:") {
+			t.Fatalf("request Host header got %q, want localhost:<port>", r.Host)
+		}
+		_, _ = w.Write([]byte(`["localhost","node-a.internal"]`))
+	}))
+	server.Listener = listener
+	server.Start()
+	defer server.Close()
+
+	_, port := splitServerHostPort(t, server.URL)
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"localhost"},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("DNS seed should be contacted once, got %d requests", got)
+	}
+	got := hostnames(aln.GetNodes())
+	want := []string{"localhost", "node-a.internal"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("GetNodes got %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #108.
- Add shared live-node unit coverage for a DNS hostname seed entrypoint and DNS hostname records returned from `/localnodes`.
- Add SDK v1 and SDK v2 integration coverage that discovers through a resolver-backed `localhost` entrypoint using live `/localnodes` data.
- Check integration helper response-body cleanup so `errcheck` passes in CI.

## Tests
- `go test ./shared -run TestAlternatorLiveNodes_DNSEntrypointDiscoversDNSNodeRecords -count=1`
- `go test -tags integration ./sdkv1 -run '^$'`
- `go test -tags integration ./sdkv2 -run '^$'`
- `make check`
- `git diff --check`