### PR TITLE
Support IPv6 and dual-stack entrypoints

### DIFF
--- a/shared/ipv6_dns_test.go
+++ b/shared/ipv6_dns_test.go
@@ -1,0 +1,372 @@
+// Copyright ScyllaDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
+)
+
+func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
+	tests := []struct {
+		name        string
+		listenIPs   []string
+		dnsIPs      []string
+		learnedIPs  []string
+		wantFailure bool
+	}{
+		{
+			name:       "IPv6-only DNS",
+			listenIPs:  []string{"::1"},
+			dnsIPs:     []string{"::1"},
+			learnedIPs: []string{"::1"},
+		},
+		{
+			name:       "dual-stack DNS with both families reachable",
+			listenIPs:  []string{"127.0.0.1", "::1"},
+			dnsIPs:     []string{"127.0.0.1", "::1"},
+			learnedIPs: []string{"127.0.0.1", "::1"},
+		},
+		{
+			name:       "broken IPv6 record falls back to IPv4",
+			listenIPs:  []string{"127.0.0.1"},
+			dnsIPs:     []string{"2001:db8::dead", "127.0.0.1"},
+			learnedIPs: []string{"127.0.0.1"},
+		},
+		{
+			name:       "broken IPv4 record falls back to IPv6",
+			listenIPs:  []string{"::1"},
+			dnsIPs:     []string{"192.0.2.123", "::1"},
+			learnedIPs: []string{"::1"},
+		},
+		{
+			name:        "all DNS records unavailable",
+			dnsIPs:      []string{"192.0.2.123", "2001:db8::dead"},
+			wantFailure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listeners, port := listenOnAddressFamilies(t, tt.listenIPs)
+			var discoveryRequests atomic.Int32
+			var operationRequests atomic.Int32
+			servers := startAddressFamilyServers(
+				t,
+				listeners,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/localnodes":
+						discoveryRequests.Add(1)
+						_ = json.NewEncoder(w).Encode(tt.learnedIPs)
+					case "/":
+						operationRequests.Add(1)
+						_, _ = w.Write([]byte("OK"))
+					default:
+						http.Error(w, "unexpected path", http.StatusNotFound)
+					}
+				}),
+			)
+			for _, server := range servers {
+				defer server.Close()
+			}
+
+			if port == 0 {
+				port = unusedLoopbackPort(t)
+			}
+			resolver := resolverReturning(t, "entrypoint.test", tt.dnsIPs)
+			dialer := &net.Dialer{
+				Timeout:       300 * time.Millisecond,
+				FallbackDelay: 10 * time.Millisecond,
+				Resolver:      resolver,
+			}
+			nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+			nodeHealthConfig.Disabled = true
+			aln, err := NewAlternatorLiveNodes(
+				[]string{"entrypoint.test"},
+				WithALNPort(port),
+				WithALNUpdatePeriod(0),
+				WithALNIdleUpdatePeriod(-1),
+				WithALNHTTPClientTimeout(time.Second),
+				WithALNNodeHealthStoreConfig(nodeHealthConfig),
+				WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+					transport := roundTripper.(*http.Transport)
+					transport.Proxy = nil
+					transport.DialContext = dialer.DialContext
+					return transport
+				}),
+			)
+			if err != nil {
+				t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+			}
+			defer aln.Stop()
+
+			err = aln.UpdateLiveNodes()
+			if tt.wantFailure {
+				if err == nil {
+					t.Fatal("UpdateLiveNodes succeeded with no reachable DNS records")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateLiveNodes returned error: %v", err)
+			}
+			if discoveryRequests.Load() == 0 {
+				t.Fatal("DNS entrypoint did not receive /localnodes request")
+			}
+
+			gotHosts := hostnames(aln.GetNodes())
+			slices.Sort(gotHosts)
+			wantHosts := slices.Clone(tt.learnedIPs)
+			slices.Sort(wantHosts)
+			if !slices.Equal(gotHosts, wantHosts) {
+				t.Fatalf("discovered hosts got %v, want %v", gotHosts, wantHosts)
+			}
+			for _, node := range aln.GetNodes() {
+				response, requestErr := aln.httpClient.Get(node.String())
+				if requestErr != nil {
+					t.Fatalf("normal request through learned node %s failed: %v", node.String(), requestErr)
+				}
+				drainAndCloseResponseBody(response.Body)
+				if response.StatusCode != http.StatusOK {
+					t.Fatalf(
+						"normal request through learned node %s returned HTTP %d",
+						node.String(),
+						response.StatusCode,
+					)
+				}
+			}
+			if got, want := operationRequests.Load(), int32(len(tt.learnedIPs)); got != want {
+				t.Fatalf("normal operation requests got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func listenOnAddressFamilies(t *testing.T, ips []string) ([]net.Listener, int) {
+	t.Helper()
+	if len(ips) == 0 {
+		return nil, 0
+	}
+
+	listeners := make([]net.Listener, 0, len(ips))
+	port := 0
+	for _, ip := range ips {
+		network := "tcp4"
+		if net.ParseIP(ip).To4() == nil {
+			network = "tcp6"
+		}
+		listener, err := net.Listen(network, net.JoinHostPort(ip, strconv.Itoa(port)))
+		if err != nil {
+			for _, opened := range listeners {
+				_ = opened.Close()
+			}
+			if network == "tcp6" {
+				t.Skipf("IPv6 loopback is unavailable: %v", err)
+			}
+			t.Fatalf("failed to listen on %s: %v", ip, err)
+		}
+		listeners = append(listeners, listener)
+		if port == 0 {
+			_, portString, splitErr := net.SplitHostPort(listener.Addr().String())
+			if splitErr != nil {
+				t.Fatalf("failed to split listener address: %v", splitErr)
+			}
+			port, err = strconv.Atoi(portString)
+			if err != nil {
+				t.Fatalf("failed to parse listener port: %v", err)
+			}
+		}
+	}
+	return listeners, port
+}
+
+func startAddressFamilyServers(t *testing.T, listeners []net.Listener, handler http.Handler) []*httptest.Server {
+	t.Helper()
+	servers := make([]*httptest.Server, 0, len(listeners))
+	for _, listener := range listeners {
+		server := httptest.NewUnstartedServer(handler)
+		server.Listener = listener
+		server.Start()
+		servers = append(servers, server)
+	}
+	return servers
+}
+
+func unusedLoopbackPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a loopback port: %v", err)
+	}
+	_, portString, err := net.SplitHostPort(listener.Addr().String())
+	_ = listener.Close()
+	if err != nil {
+		t.Fatalf("failed to split reserved loopback address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse reserved loopback port: %v", err)
+	}
+	return port
+}
+
+func resolverReturning(t *testing.T, hostname string, ips []string) *net.Resolver {
+	t.Helper()
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(_ context.Context, network, _ string) (net.Conn, error) {
+			client, server := net.Pipe()
+			tcp := strings.HasPrefix(network, "tcp")
+			go serveDNSQuery(t, server, tcp, hostname, ips)
+			if tcp {
+				return client, nil
+			}
+			return &pipePacketConn{Conn: client}, nil
+		},
+	}
+}
+
+type pipePacketConn struct {
+	net.Conn
+}
+
+func (c *pipePacketConn) ReadFrom(buffer []byte) (int, net.Addr, error) {
+	n, err := c.Read(buffer)
+	return n, c.RemoteAddr(), err
+}
+
+func (c *pipePacketConn) WriteTo(buffer []byte, _ net.Addr) (int, error) {
+	return c.Write(buffer)
+}
+
+func serveDNSQuery(t *testing.T, conn net.Conn, tcp bool, hostname string, ips []string) {
+	t.Helper()
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	query := make([]byte, 2048)
+	n, err := conn.Read(query)
+	if err != nil {
+		return
+	}
+	query = query[:n]
+	if tcp {
+		response, responseErr := dnsResponse(query[2:], hostname, ips)
+		if responseErr != nil {
+			t.Errorf("failed to create DNS response: %v", responseErr)
+			return
+		}
+		framed := make([]byte, len(response)+2)
+		binary.BigEndian.PutUint16(framed[:2], uint16(len(response)))
+		copy(framed[2:], response)
+		_, _ = conn.Write(framed)
+		return
+	}
+	response, responseErr := dnsResponse(query, hostname, ips)
+	if responseErr != nil {
+		t.Errorf("failed to create DNS response: %v", responseErr)
+		return
+	}
+	_, _ = conn.Write(response)
+}
+
+func dnsResponse(query []byte, hostname string, ips []string) ([]byte, error) {
+	if len(query) < 17 {
+		return nil, fmt.Errorf("short DNS query")
+	}
+	offset := 12
+	var labels []string
+	for {
+		if offset >= len(query) {
+			return nil, fmt.Errorf("truncated DNS name")
+		}
+		length := int(query[offset])
+		offset++
+		if length == 0 {
+			break
+		}
+		if offset+length > len(query) {
+			return nil, fmt.Errorf("truncated DNS label")
+		}
+		labels = append(labels, string(query[offset:offset+length]))
+		offset += length
+	}
+	if offset+4 > len(query) {
+		return nil, fmt.Errorf("truncated DNS question")
+	}
+	if got := joinDNSLabels(labels); got != hostname {
+		return nil, fmt.Errorf("DNS query for %q, want %q", got, hostname)
+	}
+	questionEnd := offset + 4
+	queryType := binary.BigEndian.Uint16(query[offset : offset+2])
+
+	var answers [][]byte
+	for _, value := range ips {
+		ip := net.ParseIP(value)
+		var record []byte
+		switch queryType {
+		case 1:
+			record = ip.To4()
+		case 28:
+			if ip.To4() == nil {
+				record = ip.To16()
+			}
+		}
+		if record != nil {
+			answers = append(answers, record)
+		}
+	}
+
+	response := make([]byte, 12, 12+questionEnd-12+len(answers)*28)
+	copy(response[:2], query[:2])
+	binary.BigEndian.PutUint16(response[2:4], 0x8180)
+	binary.BigEndian.PutUint16(response[4:6], 1)
+	binary.BigEndian.PutUint16(response[6:8], uint16(len(answers)))
+	response = append(response, query[12:questionEnd]...)
+	for _, answer := range answers {
+		header := make([]byte, 12)
+		binary.BigEndian.PutUint16(header[0:2], 0xc00c)
+		binary.BigEndian.PutUint16(header[2:4], queryType)
+		binary.BigEndian.PutUint16(header[4:6], 1)
+		binary.BigEndian.PutUint16(header[10:12], uint16(len(answer)))
+		response = append(response, header...)
+		response = append(response, answer...)
+	}
+	return response, nil
+}
+
+func joinDNSLabels(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	out := labels[0]
+	for _, label := range labels[1:] {
+		out += "." + label
+	}
+	return out
+}

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -22,11 +22,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"slices"
 	"sort"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -315,13 +319,14 @@ func NewAlternatorLiveNodes(initialNodes []string, options ...ALNOption) (*Alter
 
 	nodes := make([]url.URL, len(initialNodes))
 	for i, node := range initialNodes {
-		parsed, err := url.Parse(fmt.Sprintf("%s://%s:%d", cfg.Scheme, node, cfg.Port))
+		uri, err := nodeURL(cfg.Scheme, node, cfg.Port)
 		if err != nil {
-			return nil, fmt.Errorf("invalid node URI: %w", err)
+			return nil, fmt.Errorf("invalid node URI %q: %w", node, err)
 		}
-		nodes[i] = *parsed
+		nodes[i] = uri
 	}
 	sortNodesByAddress(nodes)
+	initialNodeURLs := slices.Clone(nodes)
 
 	nodeHealthStore, err := nodeshealth.NewNodeHealthStore(
 		cfg.NodeHealthStoreConfig,
@@ -341,13 +346,13 @@ func NewAlternatorLiveNodes(initialNodes []string, options ...ALNOption) (*Alter
 			}
 			return true
 		},
-		nodes)
+		slices.Clone(nodes))
 	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	out := &AlternatorLiveNodes{
-		initialNodes:    nodes,
+		initialNodes:    initialNodeURLs,
 		cfg:             cfg,
 		ctx:             ctx,
 		stopFn:          cancel,
@@ -475,7 +480,37 @@ func (aln *AlternatorLiveNodes) getNodesForScope(scope rt.Scope) ([]url.URL, err
 	plan := NewLazyQueryPlan(aln)
 	var discoveredNodes []url.URL
 	var lastErr error
+	attempted := make(map[string]struct{})
 	for node := plan.Next(); node.Host != ""; node = plan.Next() {
+		attempted[node.String()] = struct{}{}
+		endpoint := node
+		endpoint.Path = "/localnodes"
+		endpoint.RawQuery = scope.GetLocalNodesQuery()
+
+		newNodes, err := aln.getNodes(&endpoint)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(newNodes) == 0 {
+			continue
+		}
+		if !clusterScope {
+			return newNodes, nil
+		}
+		discoveredNodes = append(discoveredNodes, newNodes...)
+	}
+	if len(discoveredNodes) != 0 {
+		return cloneAndDedupeNodes(discoveredNodes), nil
+	}
+
+	// Successful discovery replaces the initial entrypoints in the active node set. If every
+	// learned node later fails, retry the original entrypoints so a long-lived client can relearn
+	// the cluster without being recreated.
+	for _, node := range aln.initialNodes {
+		if _, ok := attempted[node.String()]; ok {
+			continue
+		}
 		endpoint := node
 		endpoint.Path = "/localnodes"
 		endpoint.RawQuery = scope.GetLocalNodesQuery()
@@ -555,14 +590,36 @@ func (aln *AlternatorLiveNodes) getNodes(endpoint *url.URL) ([]url.URL, error) {
 
 	var uris []url.URL
 	for _, node := range nodes {
-		nodeURL, err := url.Parse(fmt.Sprintf("%s://%s:%d", aln.cfg.Scheme, node, aln.cfg.Port))
+		uri, err := nodeURL(aln.cfg.Scheme, node, aln.cfg.Port)
 		if err != nil {
-			aln.cfg.Logger.Error(fmt.Errorf("failed to parse node list entry: %w", err).Error())
+			aln.cfg.Logger.Error("invalid node URI", logx.A("node", node), logx.A("error", err))
 			continue
 		}
-		uris = append(uris, *nodeURL)
+		uris = append(uris, uri)
 	}
 	return sortNodesByAddress(uris), nil
+}
+
+func nodeURL(scheme, host string, port int) (url.URL, error) {
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	if host == "" {
+		return url.URL{}, errors.New("host cannot be empty")
+	}
+	if strings.Contains(host, ":") {
+		if _, err := netip.ParseAddr(host); err != nil {
+			return url.URL{}, fmt.Errorf("invalid IPv6 address: %w", err)
+		}
+	}
+	uri := url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+	}
+	if _, err := url.Parse(uri.String()); err != nil {
+		return url.URL{}, err
+	}
+	return uri, nil
 }
 
 func drainAndCloseResponseBody(body io.ReadCloser) {

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -15,6 +15,7 @@
 package shared
 
 import (
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -183,6 +184,231 @@ func TestAlternatorLiveNodes_DNSEntrypointDiscoversDNSNodeRecords(t *testing.T) 
 	want := []string{"localhost", "node-a.internal"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("GetNodes got %v, want %v", got, want)
+	}
+}
+
+func TestAlternatorLiveNodes_IPv6LiteralDiscoversAndRoutesRequests(t *testing.T) {
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+
+	var discoveryRequests atomic.Int32
+	var operationRequests atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != listener.Addr().String() {
+			t.Errorf("request Host header got %q, want %q", r.Host, listener.Addr().String())
+		}
+		switch r.URL.Path {
+		case "/localnodes":
+			discoveryRequests.Add(1)
+			_, _ = w.Write([]byte(`["::1"]`))
+		case "/":
+			operationRequests.Add(1)
+			_, _ = w.Write([]byte("OK"))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	server.Listener = listener
+	server.Start()
+	defer server.Close()
+
+	_, port := splitServerHostPort(t, server.URL)
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"::1"},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	wantURL := "http://" + listener.Addr().String()
+	initialNode := aln.NextNode()
+	if got := initialNode.String(); got != wantURL {
+		t.Fatalf("initial IPv6 node URL got %q, want %q", got, wantURL)
+	}
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	discoveredNode := aln.NextNode()
+	if got := discoveredNode.String(); got != wantURL {
+		t.Fatalf("discovered IPv6 node URL got %q, want %q", got, wantURL)
+	}
+
+	routedNode := aln.NextNode()
+	response, err := aln.httpClient.Get(routedNode.String())
+	if err != nil {
+		t.Fatalf("request through discovered IPv6 node failed: %v", err)
+	}
+	drainAndCloseResponseBody(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("request through discovered IPv6 node returned HTTP %d", response.StatusCode)
+	}
+	if got := discoveryRequests.Load(); got != 1 {
+		t.Fatalf("discovery requests got %d, want 1", got)
+	}
+	if got := operationRequests.Load(); got != 1 {
+		t.Fatalf("operation requests got %d, want 1", got)
+	}
+}
+
+func TestAlternatorLiveNodes_FallsBackToOriginalIPv6Entrypoint(t *testing.T) {
+	t.Parallel()
+
+	var seedRequests atomic.Int32
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"2001:db8::1"},
+		WithALNPort(8080),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path != "/localnodes" {
+					t.Fatalf("unexpected request path %q", req.URL.Path)
+				}
+				switch req.URL.Hostname() {
+				case "2001:db8::1":
+					if req.URL.Host != "[2001:db8::1]:8080" {
+						t.Fatalf("IPv6 entrypoint authority got %q, want %q", req.URL.Host, "[2001:db8::1]:8080")
+					}
+					if seedRequests.Add(1) == 1 {
+						return resp.AlternatorNodesResponse([]string{"2001:db8::2"}, req)
+					}
+					return resp.AlternatorNodesResponse([]string{"2001:db8::3"}, req)
+				case "2001:db8::2":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("malformed")),
+						Header:     make(http.Header),
+						Request:    req,
+					}, nil
+				default:
+					t.Fatalf("unexpected discovery host %q", req.URL.Hostname())
+					return nil, nil
+				}
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("first UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"2001:db8::2"}) {
+		t.Fatalf("first discovery got %v, want [2001:db8::2]", got)
+	}
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("recovery UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"2001:db8::3"}) {
+		t.Fatalf("recovery discovery got %v, want [2001:db8::3]", got)
+	}
+	if got := seedRequests.Load(); got != 2 {
+		t.Fatalf("original IPv6 entrypoint requests got %d, want 2", got)
+	}
+}
+
+func TestNodeURLFormatsHostAndPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "DNS", host: "alternator.example.com", want: "https://alternator.example.com:8043"},
+		{name: "IPv4", host: "192.0.2.10", want: "https://192.0.2.10:8043"},
+		{name: "IPv6", host: "2001:db8::10", want: "https://[2001:db8::10]:8043"},
+		{name: "scoped IPv6", host: "fe80::10%eth0", want: "https://[fe80::10%25eth0]:8043"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := nodeURL("https", tt.host, 8043)
+			if err != nil {
+				t.Fatalf("nodeURL() returned error: %v", err)
+			}
+			if got.String() != tt.want {
+				t.Fatalf("nodeURL().String() got %q, want %q", got.String(), tt.want)
+			}
+			if got.Hostname() != tt.host {
+				t.Fatalf("nodeURL().Hostname() got %q, want %q", got.Hostname(), tt.host)
+			}
+		})
+	}
+}
+
+func TestNewAlternatorLiveNodesRejectsMalformedHost(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewAlternatorLiveNodes([]string{"bad host"}); err == nil {
+		t.Fatal("NewAlternatorLiveNodes() accepted a malformed host")
+	}
+}
+
+func TestAlternatorLiveNodesSkipsMalformedDiscoveredHost(t *testing.T) {
+	t.Parallel()
+
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"seed.local"},
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return resp.AlternatorNodesResponse([]string{"bad host", "::1"}, req)
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"::1"}) {
+		t.Fatalf("discovered hosts got %v, want [::1]", got)
+	}
+}
+
+func TestAlternatorLiveNodesKeepsIndependentInitialNodesWhenHealthDisabled(t *testing.T) {
+	t.Parallel()
+
+	healthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	healthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"seed-a.local", "seed-b.local"},
+		WithALNNodeHealthStoreConfig(healthConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return resp.AlternatorNodesResponse([]string{"seed-b.local"}, req)
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.initialNodes); !slices.Equal(got, []string{"seed-a.local", "seed-b.local"}) {
+		t.Fatalf("initial nodes were mutated to %v", got)
 	}
 }
 


### PR DESCRIPTION
Jira task: https://scylladb.atlassian.net/browse/DRIVER-911
Jira epic: https://scylladb.atlassian.net/browse/DRIVER-823

## Summary
- build initial and discovered node URLs with `net.JoinHostPort` so IPv6 literals are correctly bracketed
- retry the original entrypoints when every learned live node can no longer refresh discovery
- cover IPv4-only, IPv6-only, dual-stack, cross-family fallback, direct IPv6, all-record failure, and post-discovery request routing

## Tests
- `go test ./shared/... ./sdkv1/... ./sdkv2/... -count=1`