### PR TITLE
Implement resilient DNS entrypoint recovery

### DIFF
--- a/sdkv1/helper.go
+++ b/sdkv1/helper.go
@@ -52,6 +52,7 @@ package sdkv1
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"runtime/debug"
@@ -103,6 +104,9 @@ var (
 
 	// WithIdleNodesListUpdatePeriod configures how often update list of nodes, while no requests are running
 	WithIdleNodesListUpdatePeriod = shared.WithIdleNodesListUpdatePeriod
+
+	// WithDNSResolver sets the resolver used by discovery and normal SDK requests.
+	WithDNSResolver = shared.WithDNSResolver
 
 	// WithCredentials provides credentials to DynamoDB client, which could be used by Alternator as well
 	WithCredentials = shared.WithCredentials
@@ -214,9 +218,14 @@ type AlternatorNodesSource interface {
 	CheckIfRackAndDatacenterSetCorrectly() error
 	CheckIfRackDatacenterFeatureIsSupported() (bool, error)
 	ReportNodeError(nodeURL url.URL, err error)
+	ReportNodeSuccess(nodeURL url.URL)
 	TryReleaseQuarantinedNodes() []url.URL
 	Start()
 	Stop()
+}
+
+type dnsResolverUpdater interface {
+	UpdateDNSResolver(*net.Resolver)
 }
 
 var _ AlternatorNodesSource = &shared.AlternatorLiveNodes{}
@@ -362,6 +371,11 @@ func (lb *Helper) Update(opts ...Option) *Helper {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	if cfg.DNSResolver != lb.cfg.DNSResolver {
+		if updater, ok := lb.nodes.(dnsResolverUpdater); ok {
+			updater.UpdateDNSResolver(cfg.DNSResolver)
+		}
+	}
 	return &Helper{
 		nodes: lb.nodes,
 		cfg:   cfg,
@@ -423,6 +437,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.originalTransport.RoundTrip(req)
 	if err != nil && req.URL != nil {
 		rt.lb.nodes.ReportNodeError(node, err)
+	} else if err == nil {
+		rt.lb.nodes.ReportNodeSuccess(node)
 	}
 	return resp, err
 }

--- a/sdkv1/helper_unit_test.go
+++ b/sdkv1/helper_unit_test.go
@@ -15,6 +15,8 @@
 package sdkv1
 
 import (
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -23,18 +25,46 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/klauspost/compress/gzip"
 
+	"github.com/scylladb/alternator-client-golang/shared"
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
+	testhelpers "github.com/scylladb/alternator-client-golang/shared/tests/helpers"
 	"github.com/scylladb/alternator-client-golang/shared/tests/mocks"
 	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
+
+type dnsResolverUpdateRecorderV1 struct {
+	AlternatorNodesSource
+	resolver *net.Resolver
+}
+
+func (r *dnsResolverUpdateRecorderV1) UpdateDNSResolver(resolver *net.Resolver) {
+	r.resolver = resolver
+}
+
+func TestHelperUpdatePropagatesDNSResolver(t *testing.T) {
+	t.Parallel()
+
+	recorder := &dnsResolverUpdateRecorderV1{}
+	helper := &Helper{nodes: recorder, cfg: *shared.NewDefaultConfig()}
+	resolver := &net.Resolver{}
+	updated := helper.Update(WithDNSResolver(resolver))
+	if recorder.resolver != resolver {
+		t.Fatal("Helper.Update did not propagate the DNS resolver to discovery")
+	}
+	if updated.cfg.DNSResolver != resolver {
+		t.Fatal("Helper.Update did not retain the DNS resolver for SDK requests")
+	}
+}
 
 func TestOptions(t *testing.T) {
 	t.Parallel()
@@ -476,6 +506,249 @@ func TestOptions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestLiveNodeManagerRecoveryRoutesOperationsToLearnedNode(t *testing.T) {
+	t.Parallel()
+
+	var recovery atomic.Bool
+	var hostsMu sync.Mutex
+	var operationHosts []string
+	mockTransport := &mocks.MockRoundTripper{
+		AlternatorRequest: func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Hostname() {
+			case "entrypoint.local":
+				if recovery.Load() {
+					return resp.AlternatorNodesResponse([]string{"new.local"}, request)
+				}
+				return resp.AlternatorNodesResponse([]string{"old.local"}, request)
+			case "old.local":
+				return nil, errors.New("old node unavailable")
+			default:
+				return nil, errors.New("unexpected discovery node")
+			}
+		},
+		NodeHealthRequest: resp.HealthCheckResponse,
+		DynamoDBRequest: func(request *http.Request) (*http.Response, error) {
+			hostsMu.Lock()
+			operationHosts = append(operationHosts, request.URL.Hostname())
+			hostsMu.Unlock()
+			if request.URL.Hostname() == "old.local" {
+				return nil, errors.New("old node unavailable")
+			}
+			if request.URL.Hostname() != "new.local" {
+				return nil, errors.New("normal operation used a discovery seed")
+			}
+			return resp.DynamoDBListTablesResponse([]string{"recovered"}, request)
+		},
+	}
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	helper, err := NewHelper(
+		[]string{"entrypoint.local"},
+		WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
+		WithNodeHealthStoreConfig(storeConfig),
+		WithNodesListUpdatePeriod(0),
+		WithIdleNodesListUpdatePeriod(-1),
+		WithCredentials("test-key", "test-secret"),
+		WithAWSConfigOptions(func(config *aws.Config) {
+			config.MaxRetries = aws.Int(0)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer helper.Stop()
+	if err := helper.UpdateLiveNodes(); err != nil {
+		t.Fatalf("initial UpdateLiveNodes returned error: %v", err)
+	}
+	client, err := helper.NewDynamoDB()
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+	recovery.Store(true)
+	if _, err := client.ListTables(&dynamodb.ListTablesInput{}); err == nil {
+		t.Fatal("ListTables unexpectedly succeeded through the failed learned node")
+	}
+	deadline := time.Now().Add(time.Second)
+	for helper.GetNodes()[0].Hostname() != "new.local" {
+		if time.Now().After(deadline) {
+			t.Fatal("live-node manager did not recover through the original entrypoint")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	output, err := client.ListTables(&dynamodb.ListTablesInput{})
+	if err != nil {
+		t.Fatalf("ListTables after live-node recovery returned error: %v", err)
+	}
+	if len(output.TableNames) != 1 || aws.StringValue(output.TableNames[0]) != "recovered" {
+		t.Fatalf("ListTables after recovery returned %v", output.TableNames)
+	}
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+	if len(operationHosts) != 2 || operationHosts[0] != "old.local" || operationHosts[1] != "new.local" {
+		t.Fatalf("normal operation hosts got %v, want [old.local new.local]", operationHosts)
+	}
+}
+
+func TestPartialOperationFailureUsesRemainingLearnedNodeWithoutRefresh(t *testing.T) {
+	t.Parallel()
+
+	var discoveryRequests atomic.Int32
+	var operationRequests atomic.Int32
+	var hostsMu sync.Mutex
+	var operationHosts []string
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	helper, err := NewHelper(
+		[]string{"entrypoint.local"},
+		WithNodeHealthStoreConfig(storeConfig),
+		WithNodesListUpdatePeriod(0),
+		WithIdleNodesListUpdatePeriod(-1),
+		WithCredentials("test-key", "test-secret"),
+		WithAWSConfigOptions(func(config *aws.Config) {
+			config.MaxRetries = aws.Int(1)
+			config.SleepDelay = func(time.Duration) {}
+		}),
+		WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return &mocks.MockRoundTripper{
+				AlternatorRequest: func(request *http.Request) (*http.Response, error) {
+					discoveryRequests.Add(1)
+					return resp.AlternatorNodesResponse([]string{"node-a.local", "node-b.local"}, request)
+				},
+				NodeHealthRequest: resp.HealthCheckResponse,
+				DynamoDBRequest: func(request *http.Request) (*http.Response, error) {
+					hostsMu.Lock()
+					operationHosts = append(operationHosts, request.URL.Hostname())
+					hostsMu.Unlock()
+					if operationRequests.Add(1) == 1 {
+						return nil, errors.New("first learned node unavailable")
+					}
+					return resp.DynamoDBListTablesResponse([]string{"surviving"}, request)
+				},
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer helper.Stop()
+	if err := helper.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	client, err := helper.NewDynamoDB()
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+	if _, err := client.ListTables(&dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("ListTables did not use surviving learned node: %v", err)
+	}
+	if got := discoveryRequests.Load(); got != 1 {
+		t.Fatalf("partial failure triggered %d discovery requests, want initial request only", got)
+	}
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+	if len(operationHosts) != 2 || operationHosts[0] == operationHosts[1] {
+		t.Fatalf("operation hosts got %v, want two distinct learned nodes", operationHosts)
+	}
+}
+
+func TestDNSFallbackPreservesTLSAndSigning(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+	logicalHost := net.JoinHostPort("example.com", portText)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if request.Host != logicalHost || request.TLS == nil || request.TLS.ServerName != "example.com" {
+			t.Errorf("logical TLS endpoint got Host=%q TLS=%v", request.Host, request.TLS)
+		}
+		authorization := request.Header.Get("Authorization")
+		if !strings.HasPrefix(authorization, "AWS4-HMAC-SHA256 ") ||
+			!strings.Contains(authorization, "Credential=test-key/") ||
+			!strings.Contains(authorization, "/test-region/dynamodb/aws4_request") ||
+			!signedHeadersContainHost(authorization) {
+			t.Errorf("unexpected Authorization header %q", authorization)
+		}
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		_, _ = w.Write([]byte(`{"TableNames":["signed"]}`))
+	}))
+	server.Listener = listener
+	server.StartTLS()
+	defer server.Close()
+	certificatePool := x509.NewCertPool()
+	certificatePool.AddCert(server.Certificate())
+
+	resolver := testhelpers.NewStaticResolver(
+		"example.com",
+		[]string{"127.0.0.2", "127.0.0.1"},
+	)
+	directTransport := func(roundTripper http.RoundTripper) http.RoundTripper {
+		transport := roundTripper.(*http.Transport)
+		transport.Proxy = nil
+		return transport
+	}
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	helper, err := NewHelper(
+		[]string{"example.com"},
+		WithScheme("https"),
+		WithPort(port),
+		WithAWSRegion("test-region"),
+		WithCredentials("test-key", "test-secret"),
+		WithDNSResolver(resolver),
+		WithServerCACertificatePool(certificatePool),
+		WithNodeHealthStoreConfig(storeConfig),
+		WithHTTPTransportWrapper(directTransport),
+		WithAWSConfigOptions(func(config *aws.Config) { config.MaxRetries = aws.Int(0) }),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer helper.Stop()
+	client, err := helper.NewDynamoDB()
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+	if _, err := client.ListTables(&dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("ListTables returned error: %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("fallback HTTPS requests got %d, want 1", got)
+	}
+}
+
+func signedHeadersContainHost(authorization string) bool {
+	start := strings.Index(authorization, "SignedHeaders=")
+	if start == -1 {
+		return false
+	}
+	value := authorization[start+len("SignedHeaders="):]
+	if end := strings.IndexByte(value, ','); end != -1 {
+		value = value[:end]
+	}
+	return slicesContains(strings.Split(value, ";"), "host")
+}
+
+func slicesContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDynamoDBNonOKResponsesKeepConnectionReusable(t *testing.T) {

--- a/sdkv2/helper.go
+++ b/sdkv2/helper.go
@@ -46,6 +46,7 @@ package sdkv2
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"runtime/debug"
@@ -112,6 +113,9 @@ var (
 
 	// WithIdleNodesListUpdatePeriod configures how often update list of nodes, while no requests are running
 	WithIdleNodesListUpdatePeriod = shared.WithIdleNodesListUpdatePeriod
+
+	// WithDNSResolver sets the resolver used by discovery and normal SDK requests.
+	WithDNSResolver = shared.WithDNSResolver
 
 	// WithCredentials provides credentials to DynamoDB client, which could be used by Alternator as well
 	WithCredentials = shared.WithCredentials
@@ -236,9 +240,14 @@ type AlternatorNodesSource interface {
 	CheckIfRackAndDatacenterSetCorrectly() error
 	CheckIfRackDatacenterFeatureIsSupported() (bool, error)
 	ReportNodeError(nodeURL url.URL, err error)
+	ReportNodeSuccess(nodeURL url.URL)
 	TryReleaseQuarantinedNodes() []url.URL
 	Start()
 	Stop()
+}
+
+type dnsResolverUpdater interface {
+	UpdateDNSResolver(*net.Resolver)
 }
 
 var _ AlternatorNodesSource = &shared.AlternatorLiveNodes{}
@@ -330,6 +339,11 @@ func (lb *Helper) Update(opts ...Option) *Helper {
 	cfg.AWSConfigOptions = shared.CloneAWSConfigOptions(cfg.AWSConfigOptions)
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	if cfg.DNSResolver != lb.cfg.DNSResolver {
+		if updater, ok := lb.nodes.(dnsResolverUpdater); ok {
+			updater.UpdateDNSResolver(cfg.DNSResolver)
+		}
 	}
 	return &Helper{
 		nodes:       lb.nodes,
@@ -454,10 +468,9 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Host = node.Host
 	resp, err := rt.originalTransport.RoundTrip(req)
 	if err != nil && req.URL != nil {
-		rt.lb.nodes.ReportNodeError(url.URL{
-			Host:   req.URL.Host,
-			Scheme: req.URL.Scheme,
-		}, err)
+		rt.lb.nodes.ReportNodeError(node, err)
+	} else if err == nil {
+		rt.lb.nodes.ReportNodeSuccess(node)
 	}
 	return resp, err
 }

--- a/sdkv2/helper_unit_test.go
+++ b/sdkv2/helper_unit_test.go
@@ -16,6 +16,8 @@ package sdkv2
 
 import (
 	"context"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -43,9 +46,34 @@ import (
 
 	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
 	"github.com/scylladb/alternator-client-golang/shared/tests/ct"
+	testhelpers "github.com/scylladb/alternator-client-golang/shared/tests/helpers"
 	"github.com/scylladb/alternator-client-golang/shared/tests/mocks"
 	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
 )
+
+type dnsResolverUpdateRecorderV2 struct {
+	AlternatorNodesSource
+	resolver *net.Resolver
+}
+
+func (r *dnsResolverUpdateRecorderV2) UpdateDNSResolver(resolver *net.Resolver) {
+	r.resolver = resolver
+}
+
+func TestHelperUpdatePropagatesDNSResolver(t *testing.T) {
+	t.Parallel()
+
+	recorder := &dnsResolverUpdateRecorderV2{}
+	helper := &Helper{nodes: recorder, cfg: *shared.NewDefaultConfig()}
+	resolver := &net.Resolver{}
+	updated := helper.Update(WithDNSResolver(resolver))
+	if recorder.resolver != resolver {
+		t.Fatal("Helper.Update did not propagate the DNS resolver to discovery")
+	}
+	if updated.cfg.DNSResolver != resolver {
+		t.Fatal("Helper.Update did not retain the DNS resolver for SDK requests")
+	}
+}
 
 func TestOptions(t *testing.T) {
 	t.Parallel()
@@ -1380,6 +1408,246 @@ func TestOptions(t *testing.T) {
 	})
 }
 
+func TestLiveNodeManagerRecoveryRoutesOperationsToLearnedNode(t *testing.T) {
+	t.Parallel()
+
+	var recovery atomic.Bool
+	var hostsMu sync.Mutex
+	var operationHosts []string
+	mockTransport := &mocks.MockRoundTripper{
+		AlternatorRequest: func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Hostname() {
+			case "entrypoint.local":
+				if recovery.Load() {
+					return resp.AlternatorNodesResponse([]string{"new.local"}, request)
+				}
+				return resp.AlternatorNodesResponse([]string{"old.local"}, request)
+			case "old.local":
+				return nil, errors.New("old node unavailable")
+			default:
+				return nil, errors.New("unexpected discovery node")
+			}
+		},
+		NodeHealthRequest: resp.HealthCheckResponse,
+		DynamoDBRequest: func(request *http.Request) (*http.Response, error) {
+			hostsMu.Lock()
+			operationHosts = append(operationHosts, request.URL.Hostname())
+			hostsMu.Unlock()
+			if request.URL.Hostname() == "old.local" {
+				return nil, errors.New("old node unavailable")
+			}
+			if request.URL.Hostname() != "new.local" {
+				return nil, errors.New("normal operation used a discovery seed")
+			}
+			return resp.DynamoDBListTablesResponse([]string{"recovered"}, request)
+		},
+	}
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	helper, err := NewHelper(
+		[]string{"entrypoint.local"},
+		WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return mockTransport }),
+		WithNodeHealthStoreConfig(storeConfig),
+		WithNodesListUpdatePeriod(0),
+		WithIdleNodesListUpdatePeriod(-1),
+		WithCredentials("test-key", "test-secret"),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer helper.Stop()
+	if err := helper.UpdateLiveNodes(); err != nil {
+		t.Fatalf("initial UpdateLiveNodes returned error: %v", err)
+	}
+	client, err := helper.NewDynamoDB(func(options *dynamodb.Options) {
+		options.Retryer = retry.NewStandard(func(options *retry.StandardOptions) {
+			options.MaxAttempts = 1
+		})
+	})
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+	recovery.Store(true)
+	if _, err := client.ListTables(context.Background(), &dynamodb.ListTablesInput{}); err == nil {
+		t.Fatal("ListTables unexpectedly succeeded through the failed learned node")
+	}
+	deadline := time.Now().Add(time.Second)
+	for helper.GetNodes()[0].Hostname() != "new.local" {
+		if time.Now().After(deadline) {
+			t.Fatal("live-node manager did not recover through the original entrypoint")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	output, err := client.ListTables(context.Background(), &dynamodb.ListTablesInput{})
+	if err != nil {
+		t.Fatalf("ListTables after live-node recovery returned error: %v", err)
+	}
+	if len(output.TableNames) != 1 || output.TableNames[0] != "recovered" {
+		t.Fatalf("ListTables after recovery returned %v", output.TableNames)
+	}
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+	if len(operationHosts) != 2 || operationHosts[0] != "old.local" || operationHosts[1] != "new.local" {
+		t.Fatalf("normal operation hosts got %v, want [old.local new.local]", operationHosts)
+	}
+}
+
+func TestPartialOperationFailureUsesRemainingLearnedNodeWithoutRefresh(t *testing.T) {
+	t.Parallel()
+
+	var discoveryRequests atomic.Int32
+	var operationRequests atomic.Int32
+	var hostsMu sync.Mutex
+	var operationHosts []string
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	helper, err := NewHelper(
+		[]string{"entrypoint.local"},
+		WithNodeHealthStoreConfig(storeConfig),
+		WithNodesListUpdatePeriod(0),
+		WithIdleNodesListUpdatePeriod(-1),
+		WithCredentials("test-key", "test-secret"),
+		WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return &mocks.MockRoundTripper{
+				AlternatorRequest: func(request *http.Request) (*http.Response, error) {
+					discoveryRequests.Add(1)
+					return resp.AlternatorNodesResponse([]string{"node-a.local", "node-b.local"}, request)
+				},
+				NodeHealthRequest: resp.HealthCheckResponse,
+				DynamoDBRequest: func(request *http.Request) (*http.Response, error) {
+					hostsMu.Lock()
+					operationHosts = append(operationHosts, request.URL.Hostname())
+					hostsMu.Unlock()
+					if operationRequests.Add(1) == 1 {
+						return nil, errors.New("first learned node unavailable")
+					}
+					return resp.DynamoDBListTablesResponse([]string{"surviving"}, request)
+				},
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer helper.Stop()
+	if err := helper.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	client, err := helper.NewDynamoDB(func(options *dynamodb.Options) {
+		options.Retryer = retry.NewStandard(func(options *retry.StandardOptions) {
+			options.MaxAttempts = 2
+			options.MaxBackoff = 0
+		})
+	})
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+	if _, err := client.ListTables(context.Background(), &dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("ListTables did not use surviving learned node: %v", err)
+	}
+	if got := discoveryRequests.Load(); got != 1 {
+		t.Fatalf("partial failure triggered %d discovery requests, want initial request only", got)
+	}
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+	if len(operationHosts) != 2 || operationHosts[0] == operationHosts[1] {
+		t.Fatalf("operation hosts got %v, want two distinct learned nodes", operationHosts)
+	}
+}
+
+func TestDNSFallbackPreservesTLSAndSigning(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+	logicalHost := net.JoinHostPort("example.com", portText)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if request.Host != logicalHost || request.TLS == nil || request.TLS.ServerName != "example.com" {
+			t.Errorf("logical TLS endpoint got Host=%q TLS=%v", request.Host, request.TLS)
+		}
+		authorization := request.Header.Get("Authorization")
+		if !strings.HasPrefix(authorization, "AWS4-HMAC-SHA256 ") ||
+			!strings.Contains(authorization, "Credential=test-key/") ||
+			!strings.Contains(authorization, "/test-region/dynamodb/aws4_request") ||
+			!signedHeadersContainHost(authorization) {
+			t.Errorf("unexpected Authorization header %q", authorization)
+		}
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		_, _ = w.Write([]byte(`{"TableNames":["signed"]}`))
+	}))
+	server.Listener = listener
+	server.StartTLS()
+	defer server.Close()
+	certificatePool := x509.NewCertPool()
+	certificatePool.AddCert(server.Certificate())
+
+	resolver := testhelpers.NewStaticResolver(
+		"example.com",
+		[]string{"127.0.0.2", "127.0.0.1"},
+	)
+	directTransport := func(roundTripper http.RoundTripper) http.RoundTripper {
+		transport := roundTripper.(*http.Transport)
+		transport.Proxy = nil
+		return transport
+	}
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	helper, err := NewHelper(
+		[]string{"example.com"},
+		WithScheme("https"),
+		WithPort(port),
+		WithAWSRegion("test-region"),
+		WithCredentials("test-key", "test-secret"),
+		WithDNSResolver(resolver),
+		WithServerCACertificatePool(certificatePool),
+		WithNodeHealthStoreConfig(storeConfig),
+		WithHTTPTransportWrapper(directTransport),
+	)
+	if err != nil {
+		t.Fatalf("NewHelper returned error: %v", err)
+	}
+	defer helper.Stop()
+	client, err := helper.NewDynamoDB(func(options *dynamodb.Options) {
+		options.Retryer = retry.NewStandard(func(options *retry.StandardOptions) {
+			options.MaxAttempts = 1
+			options.MaxBackoff = 0
+		})
+	})
+	if err != nil {
+		t.Fatalf("NewDynamoDB returned error: %v", err)
+	}
+	if _, err := client.ListTables(context.Background(), &dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("ListTables returned error: %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("fallback HTTPS requests got %d, want 1", got)
+	}
+}
+
+func signedHeadersContainHost(authorization string) bool {
+	start := strings.Index(authorization, "SignedHeaders=")
+	if start == -1 {
+		return false
+	}
+	value := authorization[start+len("SignedHeaders="):]
+	if end := strings.IndexByte(value, ','); end != -1 {
+		value = value[:end]
+	}
+	return slices.Contains(strings.Split(value, ";"), "host")
+}
+
 func TestDynamoDBNonOKResponsesKeepConnectionReusable(t *testing.T) {
 	t.Parallel()
 
@@ -2103,6 +2371,9 @@ func (s batchWriteAffinityNodeSource) UpdateLiveNodes() error {
 }
 
 func (s batchWriteAffinityNodeSource) ReportNodeError(url.URL, error) {
+}
+
+func (s batchWriteAffinityNodeSource) ReportNodeSuccess(url.URL) {
 }
 
 func (s batchWriteAffinityNodeSource) TryReleaseQuarantinedNodes() []url.URL {

--- a/shared/config.go
+++ b/shared/config.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"reflect"
@@ -77,6 +78,8 @@ type Config struct {
 	HTTPTransportWrapper func(http.RoundTripper) http.RoundTripper
 	// Timeout for HTTP requests
 	HTTPClientTimeout time.Duration
+	// DNSResolver overrides hostname resolution for discovery and SDK requests.
+	DNSResolver *net.Resolver
 	// AWSConfigOptions holds []func(*aws.Config) where the aws.Config type differs for each SDK version (v1 vs v2)
 	AWSConfigOptions []any
 	// UserAgent updates the DynamoDB request User-Agent header.
@@ -194,6 +197,9 @@ func (c *Config) ToALNOptions() []ALNOption {
 		WithALNRoutingScope(c.RoutingScope),
 		WithALNLogger(c.Logger),
 		WithALNNodeHealthStoreConfig(c.NodeHealthStoreConfig),
+	}
+	if c.DNSResolver != nil {
+		out = append(out, WithALNDNSResolver(c.DNSResolver))
 	}
 
 	if c.IdleNodesListUpdatePeriod != 0 {
@@ -558,6 +564,16 @@ func WithHTTPTransportWrapper(wrapper func(http.RoundTripper) http.RoundTripper)
 func WithHTTPClientTimeout(value time.Duration) Option {
 	return func(config *Config) {
 		config.HTTPClientTimeout = value
+	}
+}
+
+// WithDNSResolver sets the resolver used by discovery and normal SDK requests.
+func WithDNSResolver(resolver *net.Resolver) Option {
+	if resolver == nil {
+		panic("resolver can't be nil")
+	}
+	return func(config *Config) {
+		config.DNSResolver = resolver
 	}
 }
 

--- a/shared/ipv6_dns_test.go
+++ b/shared/ipv6_dns_test.go
@@ -16,12 +16,15 @@ package shared
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -65,6 +68,12 @@ func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
 			learnedIPs: []string{"::1"},
 		},
 		{
+			name:       "several leading broken records fall back to reachable address",
+			listenIPs:  []string{"127.0.0.1"},
+			dnsIPs:     []string{"127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.1"},
+			learnedIPs: []string{"127.0.0.1"},
+		},
+		{
 			name:        "all DNS records unavailable",
 			dnsIPs:      []string{"192.0.2.123", "2001:db8::dead"},
 			wantFailure: true,
@@ -100,11 +109,6 @@ func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
 				port = unusedLoopbackPort(t)
 			}
 			resolver := resolverReturning(t, "entrypoint.test", tt.dnsIPs)
-			dialer := &net.Dialer{
-				Timeout:       300 * time.Millisecond,
-				FallbackDelay: 10 * time.Millisecond,
-				Resolver:      resolver,
-			}
 			nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
 			nodeHealthConfig.Disabled = true
 			aln, err := NewAlternatorLiveNodes(
@@ -113,11 +117,11 @@ func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
 				WithALNUpdatePeriod(0),
 				WithALNIdleUpdatePeriod(-1),
 				WithALNHTTPClientTimeout(time.Second),
+				WithALNDNSResolver(resolver),
 				WithALNNodeHealthStoreConfig(nodeHealthConfig),
 				WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
 					transport := roundTripper.(*http.Transport)
 					transport.Proxy = nil
-					transport.DialContext = dialer.DialContext
 					return transport
 				}),
 			)
@@ -126,10 +130,19 @@ func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
 			}
 			defer aln.Stop()
 
+			startedAt := time.Now()
 			err = aln.UpdateLiveNodes()
 			if tt.wantFailure {
 				if err == nil {
 					t.Fatal("UpdateLiveNodes succeeded with no reachable DNS records")
+				}
+				if elapsed := time.Since(startedAt); elapsed > 2*time.Second {
+					t.Fatalf("all-address failure took %s, want at most 2s", elapsed)
+				}
+				for _, address := range tt.dnsIPs {
+					if !strings.Contains(err.Error(), address) {
+						t.Fatalf("aggregate error %q does not identify failed DNS address %s", err, address)
+					}
 				}
 				return
 			}
@@ -148,7 +161,7 @@ func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
 				t.Fatalf("discovered hosts got %v, want %v", gotHosts, wantHosts)
 			}
 			for _, node := range aln.GetNodes() {
-				response, requestErr := aln.httpClient.Get(node.String())
+				response, requestErr := aln.httpState.Load().client.Get(node.String())
 				if requestErr != nil {
 					t.Fatalf("normal request through learned node %s failed: %v", node.String(), requestErr)
 				}
@@ -165,6 +178,484 @@ func TestAlternatorLiveNodes_DNSAddressFamilies(t *testing.T) {
 				t.Fatalf("normal operation requests got %d, want %d", got, want)
 			}
 		})
+	}
+}
+
+func TestAlternatorLiveNodes_DNSAddressFallbackAfterInvalidLocalnodes(t *testing.T) {
+	t.Parallel()
+
+	const goodIP = "127.0.0.8"
+	listenIPs := []string{"127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7", goodIP}
+	listeners, port := listenOnAddressFamilies(t, listenIPs)
+	requestCounts := make(map[string]*atomic.Int32, len(listenIPs))
+	for _, ip := range listenIPs {
+		requestCounts[ip] = &atomic.Int32{}
+	}
+	var operationRequests atomic.Int32
+	servers := startAddressFamilyServers(t, listeners, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		localIP := requestLocalIP(t, r)
+		requestCounts[localIP].Add(1)
+		if r.URL.Path == "/localnodes" && r.Host != net.JoinHostPort("entrypoint.test", strconv.Itoa(port)) {
+			t.Errorf("logical Host header got %q, want entrypoint.test:%d", r.Host, port)
+		}
+		if r.URL.Path == "/" {
+			if localIP != goodIP {
+				t.Errorf("normal operation reached %s, want %s", localIP, goodIP)
+			}
+			operationRequests.Add(1)
+			_, _ = w.Write([]byte("OK"))
+			return
+		}
+		if r.URL.Path != "/localnodes" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		switch localIP {
+		case "127.0.0.2":
+			http.Redirect(w, r, "http://example.invalid/localnodes", http.StatusFound)
+		case "127.0.0.3":
+			http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+		case "127.0.0.4":
+			_, _ = w.Write([]byte("malformed"))
+		case "127.0.0.5":
+			_, _ = w.Write([]byte("[]"))
+		case "127.0.0.6":
+			_, _ = w.Write([]byte(`["bad host"]`))
+		case "127.0.0.7":
+			_, _ = w.Write([]byte("null"))
+		case goodIP:
+			_ = json.NewEncoder(w).Encode([]string{goodIP})
+		default:
+			t.Errorf("unexpected local address %q", localIP)
+		}
+	}))
+	for _, server := range servers {
+		defer server.Close()
+	}
+
+	resolver := resolverReturning(
+		t,
+		"entrypoint.test",
+		[]string{"127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7", goodIP},
+	)
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNHTTPClientTimeout(time.Second),
+		WithALNDNSResolver(resolver),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = nil
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{goodIP}) {
+		t.Fatalf("discovered hosts got %v, want [%s]", got, goodIP)
+	}
+	for _, ip := range listenIPs {
+		if got := requestCounts[ip].Load(); got != 1 {
+			t.Fatalf("/localnodes requests to %s got %d, want 1", ip, got)
+		}
+	}
+
+	node := aln.NextNode()
+	response, err := aln.httpState.Load().client.Get(node.String())
+	if err != nil {
+		t.Fatalf("normal request after DNS fallback failed: %v", err)
+	}
+	drainAndCloseResponseBody(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("normal request after DNS fallback returned HTTP %d", response.StatusCode)
+	}
+	if got := operationRequests.Load(); got != 1 {
+		t.Fatalf("normal operation requests got %d, want 1", got)
+	}
+
+	allBad, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNHTTPClientTimeout(time.Second),
+		WithALNDNSResolver(resolverReturning(t, "entrypoint.test", listenIPs[:len(listenIPs)-1])),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = nil
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes(all bad) returned error: %v", err)
+	}
+	defer allBad.Stop()
+	if err := allBad.UpdateLiveNodes(); err == nil {
+		t.Fatal("UpdateLiveNodes succeeded when every address returned unusable metadata")
+	}
+}
+
+func TestAlternatorLiveNodes_ActiveSessionReresolvesSeedAndContinuesServing(t *testing.T) {
+	t.Parallel()
+
+	listenIPs := []string{"127.0.0.2", "127.0.0.3", "127.0.0.4"}
+	listeners, port := listenOnAddressFamilies(t, listenIPs)
+	var operationRequests atomic.Int32
+	var recovery atomic.Bool
+	servers := startAddressFamilyServers(t, listeners, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		localIP := requestLocalIP(t, r)
+		if r.URL.Path == "/" {
+			if localIP != "127.0.0.4" {
+				t.Errorf("operation reached %s, want recovered node 127.0.0.4", localIP)
+			}
+			operationRequests.Add(1)
+			_, _ = w.Write([]byte("OK"))
+			return
+		}
+		if r.URL.Path != "/localnodes" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		switch localIP {
+		case "127.0.0.2":
+			if recovery.Load() {
+				http.Error(w, "old learned node unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]string{"127.0.0.2"})
+		case "127.0.0.3":
+			http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+		case "127.0.0.4":
+			_ = json.NewEncoder(w).Encode([]string{"127.0.0.4"})
+		default:
+			t.Errorf("unexpected local address %q", localIP)
+		}
+	}))
+	for _, server := range servers {
+		defer server.Close()
+	}
+
+	var dnsAnswers atomic.Value
+	dnsAnswers.Store([]string{"127.0.0.2"})
+	resolver := resolverReturningFunc(t, "entrypoint.test", func() []string {
+		return slices.Clone(dnsAnswers.Load().([]string))
+	})
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNHTTPClientTimeout(time.Second),
+		WithALNDNSResolver(resolver),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = nil
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("initial UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"127.0.0.2"}) {
+		t.Fatalf("initial hosts got %v, want [127.0.0.2]", got)
+	}
+	recovery.Store(true)
+	dnsAnswers.Store([]string{"127.0.0.3", "127.0.0.4"})
+	aln.ReportNodeError(
+		url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.2", strconv.Itoa(port))},
+		errors.New("learned node unavailable"),
+	)
+	deadline := time.Now().Add(time.Second)
+	for !slices.Equal(hostnames(aln.GetNodes()), []string{"127.0.0.4"}) {
+		if time.Now().After(deadline) {
+			t.Fatalf("automatic recovery did not publish the new live-node snapshot: %v", hostnames(aln.GetNodes()))
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"127.0.0.4"}) {
+		t.Fatalf("recovered hosts got %v, want [127.0.0.4]", got)
+	}
+	node := aln.NextNode()
+	response, err := aln.httpState.Load().client.Get(node.String())
+	if err != nil {
+		t.Fatalf("normal operation after recovery failed: %v", err)
+	}
+	drainAndCloseResponseBody(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("normal operation after recovery returned HTTP %d", response.StatusCode)
+	}
+	if got := operationRequests.Load(); got != 1 {
+		t.Fatalf("normal operation requests got %d, want 1", got)
+	}
+}
+
+func TestAlternatorLiveNodes_StalledAddressTimesOutBeforeReachableAddress(t *testing.T) {
+	t.Parallel()
+
+	listeners, port := listenOnAddressFamilies(t, []string{"127.0.0.2", "127.0.0.1"})
+	stalledListener := listeners[0]
+	accepted := make(chan error, 1)
+	release := make(chan struct{})
+	go func() {
+		connection, err := stalledListener.Accept()
+		accepted <- err
+		if err != nil {
+			return
+		}
+		defer func() { _ = connection.Close() }()
+		<-release
+	}()
+	defer func() {
+		close(release)
+		_ = stalledListener.Close()
+	}()
+
+	goodServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]string{"127.0.0.1"})
+	}))
+	goodServer.Listener = listeners[1]
+	goodServer.Start()
+	defer goodServer.Close()
+
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNPort(port),
+		WithALNHTTPClientTimeout(40*time.Millisecond),
+		WithALNDNSResolver(resolverReturning(t, "entrypoint.test", []string{"127.0.0.2", "127.0.0.1"})),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = nil
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	startedAt := time.Now()
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("stalled-address fallback took %s, want at most 1s", elapsed)
+	}
+	select {
+	case err := <-accepted:
+		if err != nil {
+			t.Fatalf("stalled server did not accept the first address attempt: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stalled server did not receive the first address attempt")
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"127.0.0.1"}) {
+		t.Fatalf("discovered hosts got %v, want [127.0.0.1]", got)
+	}
+}
+
+func TestAlternatorLiveNodes_ResetAddressFallsBackToReachableAddress(t *testing.T) {
+	t.Parallel()
+
+	listeners, port := listenOnAddressFamilies(t, []string{"127.0.0.2", "127.0.0.1"})
+	resetListener := listeners[0]
+	accepted := make(chan error, 1)
+	go func() {
+		connection, err := resetListener.Accept()
+		accepted <- err
+		if err != nil {
+			return
+		}
+		if tcpConnection, ok := connection.(*net.TCPConn); ok {
+			_ = tcpConnection.SetLinger(0)
+		}
+		_ = connection.Close()
+	}()
+	defer func() { _ = resetListener.Close() }()
+
+	goodServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]string{"127.0.0.1"})
+	}))
+	goodServer.Listener = listeners[1]
+	goodServer.Start()
+	defer goodServer.Close()
+
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNPort(port),
+		WithALNHTTPClientTimeout(time.Second),
+		WithALNDNSResolver(resolverReturning(t, "entrypoint.test", []string{"127.0.0.2", "127.0.0.1"})),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = nil
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	select {
+	case err := <-accepted:
+		if err != nil {
+			t.Fatalf("reset listener Accept returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reset address was not attempted")
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"127.0.0.1"}) {
+		t.Fatalf("discovered nodes got %v, want [127.0.0.1]", got)
+	}
+}
+
+func TestAlternatorLiveNodes_DNSAddressFallbackPreservesTLSLogicalEndpoint(t *testing.T) {
+	t.Parallel()
+
+	listeners, port := listenOnAddressFamilies(t, []string{"127.0.0.2", "127.0.0.1"})
+	servers := make([]*httptest.Server, 0, len(listeners))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != net.JoinHostPort("example.com", strconv.Itoa(port)) {
+			t.Errorf("HTTPS Host header got %q, want example.com:%d", r.Host, port)
+		}
+		serverName := ""
+		if r.TLS != nil {
+			serverName = r.TLS.ServerName
+		}
+		if serverName != "example.com" {
+			t.Errorf("TLS server name got %q, want example.com", serverName)
+		}
+		if requestLocalIP(t, r) == "127.0.0.2" {
+			http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]string{"127.0.0.1"})
+	})
+	for _, listener := range listeners {
+		server := httptest.NewUnstartedServer(handler)
+		server.Listener = listener
+		server.StartTLS()
+		servers = append(servers, server)
+		defer server.Close()
+	}
+
+	certificatePool := x509.NewCertPool()
+	for _, server := range servers {
+		certificatePool.AddCert(server.Certificate())
+	}
+	resolver := resolverReturning(t, "example.com", []string{"127.0.0.2", "127.0.0.1"})
+	nodeHealthConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	nodeHealthConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"example.com"},
+		WithALNScheme("https"),
+		WithALNPort(port),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNHTTPClientTimeout(time.Second),
+		WithALNDNSResolver(resolver),
+		WithALNServerCACertificatePool(certificatePool),
+		WithALNNodeHealthStoreConfig(nodeHealthConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = nil
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"127.0.0.1"}) {
+		t.Fatalf("discovered hosts got %v, want [127.0.0.1]", got)
+	}
+}
+
+func TestAlternatorLiveNodes_DNSFallbackPreservesConfiguredProxyResolution(t *testing.T) {
+	t.Parallel()
+
+	var proxyRequests atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		proxyRequests.Add(1)
+		if request.URL.Hostname() != "entrypoint.test" || request.Host != "entrypoint.test:8080" {
+			t.Errorf("proxy received URL=%s Host=%q", request.URL.String(), request.Host)
+		}
+		_ = json.NewEncoder(w).Encode([]string{"learned.local"})
+	}))
+	defer proxy.Close()
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+
+	var resolverCalls atomic.Int32
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			resolverCalls.Add(1)
+			return nil, errors.New("logical endpoint must be resolved by proxy")
+		},
+	}
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNPort(8080),
+		WithALNDNSResolver(resolver),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+			transport := roundTripper.(*http.Transport)
+			transport.Proxy = http.ProxyURL(proxyURL)
+			return transport
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes through proxy returned error: %v", err)
+	}
+	if got := proxyRequests.Load(); got != 1 {
+		t.Fatalf("proxy requests got %d, want 1", got)
+	}
+	if got := resolverCalls.Load(); got != 0 {
+		t.Fatalf("local resolver calls got %d, want 0 while proxy is selected", got)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"learned.local"}) {
+		t.Fatalf("discovered nodes got %v, want [learned.local]", got)
 	}
 }
 
@@ -238,18 +729,36 @@ func unusedLoopbackPort(t *testing.T) int {
 
 func resolverReturning(t *testing.T, hostname string, ips []string) *net.Resolver {
 	t.Helper()
+	return resolverReturningFunc(t, hostname, func() []string { return ips })
+}
+
+func resolverReturningFunc(t *testing.T, hostname string, ips func() []string) *net.Resolver {
+	t.Helper()
 	return &net.Resolver{
 		PreferGo: true,
 		Dial: func(_ context.Context, network, _ string) (net.Conn, error) {
 			client, server := net.Pipe()
 			tcp := strings.HasPrefix(network, "tcp")
-			go serveDNSQuery(t, server, tcp, hostname, ips)
+			go serveDNSQuery(t, server, tcp, hostname, ips())
 			if tcp {
 				return client, nil
 			}
 			return &pipePacketConn{Conn: client}, nil
 		},
 	}
+}
+
+func requestLocalIP(t *testing.T, request *http.Request) string {
+	t.Helper()
+	address, ok := request.Context().Value(http.LocalAddrContextKey).(net.Addr)
+	if !ok {
+		t.Fatal("request context has no local address")
+	}
+	host, _, err := net.SplitHostPort(address.String())
+	if err != nil {
+		t.Fatalf("split local address %q: %v", address.String(), err)
+	}
+	return host
 }
 
 type pipePacketConn struct {

--- a/shared/live_nodes.go
+++ b/shared/live_nodes.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,6 +44,11 @@ import (
 const (
 	defaultUpdatePeriod          = time.Second * 10
 	defaultIdleConnectionTimeout = 6 * time.Hour
+	defaultDiscoveryTimeout      = 30 * time.Second
+	maxDiscoveryResponseBody     = 1 << 20
+	maxDiscoverySnapshotSize     = 1 << 20
+	maxLoggedInvalidNodes        = 8
+	maxRoutingScopeDepth         = 64
 )
 
 // NodeHealthStoreInterface defines the interface for tracking node health and managing quarantined nodes.
@@ -57,6 +63,32 @@ type NodeHealthStoreInterface interface {
 	ReportNodeError(node url.URL, err error)
 }
 
+type nodeHealthSnapshotStore interface {
+	ReplaceNodes([]url.URL) bool
+	GetAllNodes() (active, quarantined []url.URL)
+}
+
+type nodeHealthReleaser interface {
+	ReleaseNode(url.URL)
+}
+
+type nodeHealthBulkReleaser interface {
+	ReleaseNodes([]url.URL)
+}
+
+type liveNodesUpdate struct {
+	done    chan struct{}
+	err     error
+	ctx     context.Context
+	cancel  context.CancelFunc
+	waiters int
+}
+
+type liveNodesHTTPState struct {
+	client   *http.Client
+	resolver *net.Resolver
+}
+
 // AlternatorLiveNodes holds logic that allows to read and remember alternator nodes
 type AlternatorLiveNodes struct {
 	liveNodes          atomic.Pointer[[]url.URL]
@@ -67,9 +99,19 @@ type AlternatorLiveNodes struct {
 	idleUpdaterStarted atomic.Bool
 	ctx                context.Context
 	stopFn             context.CancelFunc
-	httpClient         *http.Client
+	httpState          atomic.Pointer[liveNodesHTTPState]
 	updateSignal       chan struct{}
 	nodeHealthStore    NodeHealthStoreInterface
+	updateMu           sync.Mutex
+	updateInFlight     *liveNodesUpdate
+	failureMu          sync.Mutex
+	failureSnapshot    *[]url.URL
+	failedNodes        map[url.URL]struct{}
+	recoveryStarted    bool
+	lifecycleMu        sync.Mutex
+	healthCheckGate    chan struct{}
+	started            bool
+	stopped            bool
 }
 
 // GetActiveNodes returns nodes that are currently considered healthy.
@@ -80,6 +122,14 @@ func (aln *AlternatorLiveNodes) GetActiveNodes() []url.URL {
 // GetQuarantinedNodes returns nodes currently marked as unhealthy.
 func (aln *AlternatorLiveNodes) GetQuarantinedNodes() []url.URL {
 	return aln.nodeHealthStore.GetQuarantinedNodes()
+}
+
+// GetAllNodes returns one consistent health-store snapshot.
+func (aln *AlternatorLiveNodes) GetAllNodes() (active, quarantined []url.URL) {
+	if store, ok := aln.nodeHealthStore.(nodeHealthSnapshotStore); ok {
+		return store.GetAllNodes()
+	}
+	return aln.nodeHealthStore.GetActiveNodes(), aln.nodeHealthStore.GetQuarantinedNodes()
 }
 
 // ALNConfig a config for `AlternatorLiveNodes`
@@ -110,6 +160,8 @@ type ALNConfig struct {
 	HTTPTransportWrapper func(http.RoundTripper) http.RoundTripper
 	// Timeout for HTTP requests
 	HTTPClientTimeout time.Duration
+	// DNSResolver resolves DNS entrypoints. When nil, the system resolver is used.
+	DNSResolver *net.Resolver
 	// NodeHealthStoreConfig holds the entire health store configuration shared with AlternatorLiveNodes.
 	NodeHealthStoreConfig nodeshealth.NodeHealthStoreConfig
 }
@@ -292,6 +344,17 @@ func WithALNHTTPClientTimeout(value time.Duration) ALNOption {
 	}
 }
 
+// WithALNDNSResolver sets the resolver used for DNS entrypoints.
+// It is primarily useful for deterministic tests and applications with a custom resolver.
+func WithALNDNSResolver(resolver *net.Resolver) ALNOption {
+	if resolver == nil {
+		panic("resolver can't be nil")
+	}
+	return func(config *ALNConfig) {
+		config.DNSResolver = resolver
+	}
+}
+
 // WithALNNodeHealthStoreConfig overrides the default node health store configuration.
 func WithALNNodeHealthStoreConfig(storeCfg nodeshealth.NodeHealthStoreConfig) ALNOption {
 	return func(config *ALNConfig) {
@@ -328,40 +391,66 @@ func NewAlternatorLiveNodes(initialNodes []string, options ...ALNOption) (*Alter
 	sortNodesByAddress(nodes)
 	initialNodeURLs := slices.Clone(nodes)
 
-	nodeHealthStore, err := nodeshealth.NewNodeHealthStore(
-		cfg.NodeHealthStoreConfig,
-		func(u url.URL, _ nodeshealth.NodeHealthStatus) bool {
-			resp, err := httpClient.Get(u.String())
-			if err != nil {
-				cfg.Logger.Error("failed to check node health status", logx.A("node", u.String()), logx.A("error", err))
-				return false
-			}
-			defer drainAndCloseResponseBody(resp.Body)
-			if resp.StatusCode != http.StatusOK {
-				cfg.Logger.Error("failed to check node health status, node reported an error",
-					logx.A("node", u.String()),
-					logx.A("statusCode", resp.StatusCode),
-				)
-				return false
-			}
-			return true
-		},
-		slices.Clone(nodes))
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := context.WithCancel(context.Background())
+	healthCheckConcurrency := cfg.NodeHealthStoreConfig.QuarantineReleaseConcurrency
+	if healthCheckConcurrency < 1 {
+		healthCheckConcurrency = 1
+	}
+	healthCheckGate := make(chan struct{}, healthCheckConcurrency)
 	out := &AlternatorLiveNodes{
 		initialNodes:    initialNodeURLs,
 		cfg:             cfg,
 		ctx:             ctx,
 		stopFn:          cancel,
-		httpClient:      httpClient,
-		nodeHealthStore: nodeHealthStore,
 		updateSignal:    make(chan struct{}, 1),
+		healthCheckGate: healthCheckGate,
 	}
+	out.httpState.Store(&liveNodesHTTPState{client: httpClient, resolver: cfg.DNSResolver})
+	nodeHealthStore, err := nodeshealth.NewNodeHealthStore(
+		cfg.NodeHealthStoreConfig,
+		func(u url.URL, _ nodeshealth.NodeHealthStatus) bool {
+			return checkNodeHealth(ctx, u, cfg, out.httpState.Load().client, healthCheckGate)
+		},
+		slices.Clone(nodes))
+	if err != nil {
+		cancel()
+		httpClient.CloseIdleConnections()
+		return nil, err
+	}
+	out.nodeHealthStore = nodeHealthStore
 	out.liveNodes.Store(&nodes)
 	return out, nil
+}
+
+// UpdateDNSResolver replaces the resolver used by subsequent discovery and health requests.
+// Requests already in flight continue using the transport on which they started.
+func (aln *AlternatorLiveNodes) UpdateDNSResolver(resolver *net.Resolver) {
+	if resolver == nil {
+		panic("resolver can't be nil")
+	}
+	current := aln.httpState.Load()
+	if current.resolver == resolver {
+		return
+	}
+	cfg := aln.cfg
+	cfg.DNSResolver = resolver
+	replacement := &liveNodesHTTPState{
+		client: &http.Client{
+			Transport: NewALNHTTPTransport(cfg),
+			Timeout:   cfg.HTTPClientTimeout,
+		},
+		resolver: resolver,
+	}
+
+	aln.lifecycleMu.Lock()
+	if aln.stopped {
+		aln.lifecycleMu.Unlock()
+		replacement.client.CloseIdleConnections()
+		return
+	}
+	previous := aln.httpState.Swap(replacement)
+	aln.lifecycleMu.Unlock()
+	previous.client.CloseIdleConnections()
 }
 
 func (aln *AlternatorLiveNodes) triggerUpdate() {
@@ -369,9 +458,9 @@ func (aln *AlternatorLiveNodes) triggerUpdate() {
 		return
 	}
 	nextUpdate := aln.nextUpdate.Load()
-	current := time.Now().UTC().Unix()
+	current := time.Now().UTC().UnixNano()
 	if nextUpdate < current {
-		if aln.nextUpdate.CompareAndSwap(nextUpdate, current+int64(aln.cfg.UpdatePeriod.Seconds())) {
+		if aln.nextUpdate.CompareAndSwap(nextUpdate, current+int64(aln.cfg.UpdatePeriod)) {
 			select {
 			case aln.updateSignal <- struct{}{}:
 			default:
@@ -381,22 +470,27 @@ func (aln *AlternatorLiveNodes) triggerUpdate() {
 }
 
 func (aln *AlternatorLiveNodes) startIdleUpdater() {
-	if aln.cfg.IdleUpdatePeriod <= 0 {
+	if aln.cfg.IdleUpdatePeriod <= 0 && aln.cfg.UpdatePeriod <= 0 || aln.ctx.Err() != nil {
 		return
 	}
 	if aln.idleUpdaterStarted.CompareAndSwap(false, true) {
 		go func() {
-			t := time.NewTicker(aln.cfg.IdleUpdatePeriod)
-			defer t.Stop()
+			var idleUpdates <-chan time.Time
+			var idleTicker *time.Ticker
+			if aln.cfg.IdleUpdatePeriod > 0 {
+				idleTicker = time.NewTicker(aln.cfg.IdleUpdatePeriod)
+				idleUpdates = idleTicker.C
+				defer idleTicker.Stop()
+			}
 			for {
 				select {
 				case <-aln.ctx.Done():
 					return
-				case <-t.C:
-					aln.nextUpdate.Store(time.Now().UTC().Unix() + int64(aln.cfg.UpdatePeriod.Seconds()))
+				case <-idleUpdates:
+					aln.nextUpdate.Store(time.Now().UTC().UnixNano() + int64(aln.cfg.UpdatePeriod))
 					_ = aln.UpdateLiveNodes()
 				case <-aln.updateSignal:
-					aln.nextUpdate.Store(time.Now().UTC().Unix() + int64(aln.cfg.UpdatePeriod.Seconds()))
+					aln.nextUpdate.Store(time.Now().UTC().UnixNano() + int64(aln.cfg.UpdatePeriod))
 					_ = aln.UpdateLiveNodes()
 				}
 			}
@@ -407,16 +501,32 @@ func (aln *AlternatorLiveNodes) startIdleUpdater() {
 // Start begins background routines used for periodic node discovery and updates.
 // It is not required to start if automatically on first API call
 func (aln *AlternatorLiveNodes) Start() {
+	aln.lifecycleMu.Lock()
+	if aln.started || aln.stopped {
+		aln.lifecycleMu.Unlock()
+		return
+	}
+	aln.started = true
 	aln.startIdleUpdater()
-	aln.nodeHealthStore.TryReleaseQuarantinedNodes()
 	aln.nodeHealthStore.Start()
+	aln.lifecycleMu.Unlock()
+	if aln.ctx.Err() == nil {
+		aln.nodeHealthStore.TryReleaseQuarantinedNodes()
+	}
 }
 
 // Stop stops background routines used for periodic node discovery and updates.
 func (aln *AlternatorLiveNodes) Stop() {
+	aln.lifecycleMu.Lock()
+	defer aln.lifecycleMu.Unlock()
+	if aln.stopped {
+		return
+	}
+	aln.stopped = true
 	if aln.stopFn != nil {
 		aln.stopFn()
 	}
+	aln.httpState.Load().client.CloseIdleConnections()
 	aln.nodeHealthStore.Stop()
 }
 
@@ -459,77 +569,134 @@ func (aln *AlternatorLiveNodes) nextAsURLWithPath(path, query string) *url.URL {
 }
 
 // fetchLiveNodes discovers live Alternator nodes using the configured routing scope and fallbacks.
-func (aln *AlternatorLiveNodes) fetchLiveNodes() ([]url.URL, error) {
-	scope := aln.cfg.RoutingScope
-
-	for scope != nil {
-		newNodes, err := aln.getNodesForScope(scope)
+func (aln *AlternatorLiveNodes) fetchLiveNodes(ctx context.Context) ([]url.URL, error) {
+	scopes, err := routingScopes(aln.cfg.RoutingScope)
+	if err != nil {
+		return nil, err
+	}
+	for i, scope := range scopes {
+		scopeCtx, cancelScope := fairAttemptContext(ctx, len(scopes)-i)
+		newNodes, err := aln.getNodesForScope(scopeCtx, scope)
+		cancelScope()
 		if err != nil {
 			return nil, err
 		}
 		if len(newNodes) != 0 {
 			return newNodes, nil
 		}
-		scope = scope.Fallback()
 	}
 	return nil, nil
 }
 
-func (aln *AlternatorLiveNodes) getNodesForScope(scope rt.Scope) ([]url.URL, error) {
-	clusterScope := rt.IsClusterScope(scope)
+func routingScopes(scope rt.Scope) ([]rt.Scope, error) {
+	scopes := make([]rt.Scope, 0, 3)
+	for scope != nil {
+		if len(scopes) == maxRoutingScopeDepth {
+			return nil, fmt.Errorf("routing scope fallback chain exceeds %d entries", maxRoutingScopeDepth)
+		}
+		scopes = append(scopes, scope)
+		scope = scope.Fallback()
+	}
+	return scopes, nil
+}
+
+func fairAttemptContext(ctx context.Context, attemptsRemaining int) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return context.WithCancel(ctx)
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return context.WithCancel(ctx)
+	}
+	if attemptsRemaining < 1 {
+		attemptsRemaining = 1
+	}
+	reserve := remaining / 20
+	if reserve > 10*time.Millisecond {
+		reserve = 10 * time.Millisecond
+	}
+	attemptTimeout := (remaining - reserve) / time.Duration(attemptsRemaining)
+	if attemptTimeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, attemptTimeout)
+}
+
+func (aln *AlternatorLiveNodes) discoveryCandidates() []url.URL {
 	plan := NewLazyQueryPlan(aln)
-	var discoveredNodes []url.URL
-	var lastErr error
-	attempted := make(map[string]struct{})
+	candidates := make([]url.URL, 0, len(aln.GetNodes())+len(aln.initialNodes))
+	seen := make(map[string]struct{}, cap(candidates))
 	for node := plan.Next(); node.Host != ""; node = plan.Next() {
-		attempted[node.String()] = struct{}{}
-		endpoint := node
-		endpoint.Path = "/localnodes"
-		endpoint.RawQuery = scope.GetLocalNodesQuery()
-
-		newNodes, err := aln.getNodes(&endpoint)
-		if err != nil {
-			lastErr = err
+		key := node.String()
+		if _, exists := seen[key]; exists {
 			continue
 		}
-		if len(newNodes) == 0 {
-			continue
-		}
-		if !clusterScope {
-			return newNodes, nil
-		}
-		discoveredNodes = append(discoveredNodes, newNodes...)
+		seen[key] = struct{}{}
+		candidates = append(candidates, node)
 	}
-	if len(discoveredNodes) != 0 {
-		return cloneAndDedupeNodes(discoveredNodes), nil
-	}
-
-	// Successful discovery replaces the initial entrypoints in the active node set. If every
-	// learned node later fails, retry the original entrypoints so a long-lived client can relearn
-	// the cluster without being recreated.
 	for _, node := range aln.initialNodes {
-		if _, ok := attempted[node.String()]; ok {
+		key := node.String()
+		if _, exists := seen[key]; exists {
 			continue
+		}
+		seen[key] = struct{}{}
+		candidates = append(candidates, node)
+	}
+	return candidates
+}
+
+func (aln *AlternatorLiveNodes) getNodesForScope(ctx context.Context, scope rt.Scope) ([]url.URL, error) {
+	clusterScope := rt.IsClusterScope(scope)
+	var discoveredNodes []url.URL
+	discoveredKeys := make(map[string]struct{})
+	discoveredSize := 0
+	var lastErr error
+	sawEmptyResponse := false
+	candidates := aln.discoveryCandidates()
+	for i, node := range candidates {
+		if err := ctx.Err(); err != nil {
+			lastErr = err
+			break
 		}
 		endpoint := node
 		endpoint.Path = "/localnodes"
 		endpoint.RawQuery = scope.GetLocalNodesQuery()
 
-		newNodes, err := aln.getNodes(&endpoint)
+		candidateCtx, cancelCandidate := fairAttemptContext(ctx, len(candidates)-i)
+		newNodes, err := aln.getNodes(candidateCtx, &endpoint)
+		cancelCandidate()
 		if err != nil {
 			lastErr = err
 			continue
 		}
 		if len(newNodes) == 0 {
+			sawEmptyResponse = true
 			continue
 		}
 		if !clusterScope {
 			return newNodes, nil
 		}
-		discoveredNodes = append(discoveredNodes, newNodes...)
+		for _, discoveredNode := range newNodes {
+			key := discoveredNode.String()
+			if _, duplicate := discoveredKeys[key]; duplicate {
+				continue
+			}
+			discoveredSize += len(key) + 3
+			if discoveredSize > maxDiscoverySnapshotSize {
+				return nil, fmt.Errorf("discovered node snapshot exceeds %d bytes", maxDiscoverySnapshotSize)
+			}
+			discoveredKeys[key] = struct{}{}
+			discoveredNodes = append(discoveredNodes, discoveredNode)
+		}
 	}
 	if len(discoveredNodes) != 0 {
-		return cloneAndDedupeNodes(discoveredNodes), nil
+		return sortNodesByAddress(discoveredNodes), nil
+	}
+	if scope.GetLocalNodesQuery() != "" && sawEmptyResponse {
+		// A valid empty scoped result is enough to advance to the configured
+		// fallback scope even when another discovery endpoint failed.
+		return nil, nil
 	}
 	if lastErr != nil {
 		return nil, lastErr
@@ -539,65 +706,437 @@ func (aln *AlternatorLiveNodes) getNodesForScope(scope rt.Scope) ([]url.URL, err
 
 // UpdateLiveNodes forces an immediate refresh of the live Alternator nodes list.
 func (aln *AlternatorLiveNodes) UpdateLiveNodes() error {
-	newNodes, err := aln.fetchLiveNodes()
+	return aln.UpdateLiveNodesContext(context.Background())
+}
+
+func (aln *AlternatorLiveNodes) beginLiveNodesUpdate() (update *liveNodesUpdate, owner, retry bool) {
+	aln.updateMu.Lock()
+	defer aln.updateMu.Unlock()
+	if update = aln.updateInFlight; update != nil {
+		update.waiters++
+		// When the last previous waiter canceled, its shared generation is
+		// already irreversibly canceled. Wait for it to unwind, then let this
+		// still-live caller start a fresh generation instead of inheriting the
+		// abandoned generation's context error.
+		return update, false, update.ctx.Err() != nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	update = &liveNodesUpdate{done: make(chan struct{}), ctx: ctx, cancel: cancel, waiters: 1}
+	if err := aln.ctx.Err(); err != nil {
+		update.err = err
+		cancel()
+		close(update.done)
+		return update, false, false
+	}
+	aln.updateInFlight = update
+	return update, true, false
+}
+
+func (aln *AlternatorLiveNodes) finishLiveNodesUpdate(update *liveNodesUpdate, err error) {
+	aln.updateMu.Lock()
+	update.err = err
+	update.cancel()
+	if aln.updateInFlight == update {
+		aln.updateInFlight = nil
+	}
+	close(update.done)
+	aln.updateMu.Unlock()
+}
+
+func (aln *AlternatorLiveNodes) releaseLiveNodesUpdateWaiter(update *liveNodesUpdate) {
+	aln.updateMu.Lock()
+	if update.waiters > 0 {
+		update.waiters--
+	}
+	if update.waiters == 0 && aln.updateInFlight == update {
+		update.cancel()
+	}
+	aln.updateMu.Unlock()
+}
+
+func (aln *AlternatorLiveNodes) waitForLiveNodesUpdate(ctx context.Context, update *liveNodesUpdate) error {
+	defer aln.releaseLiveNodesUpdateWaiter(update)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-aln.ctx.Done():
+		return aln.ctx.Err()
+	case <-update.done:
+		return update.err
+	}
+}
+
+// UpdateLiveNodesContext forces a refresh bounded by ctx, shutdown, and the configured discovery timeout.
+func (aln *AlternatorLiveNodes) UpdateLiveNodesContext(callerCtx context.Context) error {
+	if callerCtx == nil {
+		callerCtx = context.Background()
+	}
+	if err := callerCtx.Err(); err != nil {
+		return err
+	}
+	if err := aln.ctx.Err(); err != nil {
+		return err
+	}
+	for {
+		update, owner, retry := aln.beginLiveNodesUpdate()
+		if owner {
+			go func() {
+				aln.finishLiveNodesUpdate(update, aln.updateLiveNodes(update.ctx))
+			}()
+		}
+		err := aln.waitForLiveNodesUpdate(callerCtx, update)
+		if !retry || callerCtx.Err() != nil || aln.ctx.Err() != nil {
+			return err
+		}
+	}
+}
+
+func (aln *AlternatorLiveNodes) updateLiveNodes(callerCtx context.Context) error {
+	requestCtx, cancelRequest := context.WithCancel(callerCtx)
+	stopOnShutdown := context.AfterFunc(aln.ctx, cancelRequest)
+	defer func() {
+		stopOnShutdown()
+		cancelRequest()
+	}()
+	ctx, cancelTimeout := context.WithTimeout(requestCtx, aln.discoveryTimeout())
+	defer cancelTimeout()
+
+	newNodes, err := aln.fetchLiveNodes(ctx)
 	if err != nil {
 		return err
 	}
 	if len(newNodes) == 0 {
 		return nil
 	}
-	currentNodes := *aln.liveNodes.Load()
-	hasNewNodes := false
-
-	for _, node := range newNodes {
-		if !slices.Contains(currentNodes, node) {
-			aln.nodeHealthStore.AddNode(node)
-			hasNewNodes = true
-		}
-	}
-
-	for _, node := range currentNodes {
-		if !slices.Contains(newNodes, node) {
-			aln.nodeHealthStore.RemoveNode(node)
-		}
-	}
 	sortNodesByAddress(newNodes)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	aln.lifecycleMu.Lock()
+	if aln.stopped {
+		aln.lifecycleMu.Unlock()
+		return context.Canceled
+	}
+	hasNewNodes := false
+	if store, ok := aln.nodeHealthStore.(nodeHealthSnapshotStore); ok {
+		hasNewNodes = store.ReplaceNodes(newNodes)
+	} else {
+		currentNodes := *aln.liveNodes.Load()
+		for _, node := range newNodes {
+			if !slices.Contains(currentNodes, node) {
+				aln.nodeHealthStore.AddNode(node)
+				hasNewNodes = true
+			}
+		}
+		for _, node := range currentNodes {
+			if !slices.Contains(newNodes, node) {
+				aln.nodeHealthStore.RemoveNode(node)
+			}
+		}
+	}
 	aln.liveNodes.Store(&newNodes)
+	aln.lifecycleMu.Unlock()
 	if hasNewNodes {
-		aln.nodeHealthStore.TryReleaseQuarantinedNodes()
+		aln.releaseHealthyNodes(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return nil
 }
 
-func (aln *AlternatorLiveNodes) getNodes(endpoint *url.URL) ([]url.URL, error) {
-	resp, err := aln.httpClient.Get(endpoint.String())
+func (aln *AlternatorLiveNodes) releaseHealthyNodes(ctx context.Context) {
+	bulkReleaser, canReleaseBulk := aln.nodeHealthStore.(nodeHealthBulkReleaser)
+	releaser, canReleaseOne := aln.nodeHealthStore.(nodeHealthReleaser)
+	if !canReleaseBulk && !canReleaseOne {
+		return
+	}
+	candidates := aln.nodeHealthStore.GetQuarantinedNodes()
+	healthyNodes := make([]url.URL, 0, len(candidates))
+	for i, node := range candidates {
+		if ctx.Err() != nil {
+			return
+		}
+		candidateCtx, cancelCandidate := fairAttemptContext(ctx, len(candidates)-i)
+		healthy := checkNodeHealth(candidateCtx, node, aln.cfg, aln.httpState.Load().client, aln.healthCheckGate)
+		cancelCandidate()
+		if healthy {
+			healthyNodes = append(healthyNodes, node)
+		}
+	}
+	if canReleaseBulk {
+		bulkReleaser.ReleaseNodes(healthyNodes)
+		return
+	}
+	for _, node := range healthyNodes {
+		releaser.ReleaseNode(node)
+	}
+}
+
+func checkNodeHealth(
+	ctx context.Context,
+	node url.URL,
+	cfg ALNConfig,
+	httpClient *http.Client,
+	gate chan struct{},
+) bool {
+	select {
+	case gate <- struct{}{}:
+		defer func() { <-gate }()
+	case <-ctx.Done():
+		return false
+	}
+	requestCtx, cancelRequest := context.WithTimeout(ctx, discoveryTimeoutForConfig(cfg))
+	defer cancelRequest()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, node.String(), nil)
+	if err != nil {
+		return false
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		if ctx.Err() == nil {
+			cfg.Logger.Error("failed to check node health status", logx.A("node", node.String()), logx.A("error", err))
+		}
+		return false
+	}
+	defer drainAndCloseResponseBody(response.Body)
+	if response.StatusCode != http.StatusOK {
+		cfg.Logger.Error(
+			"failed to check node health status, node reported an error",
+			logx.A("node", node.String()),
+			logx.A("statusCode", response.StatusCode),
+		)
+		return false
+	}
+	return true
+}
+
+func (aln *AlternatorLiveNodes) getNodes(ctx context.Context, endpoint *url.URL) ([]url.URL, error) {
+	httpState := aln.httpState.Load()
+	resolveCtx, cancelResolve := fairAttemptContext(ctx, 2)
+	addresses, err := aln.resolveEndpointAddresses(resolveCtx, endpoint, httpState)
+	cancelResolve()
 	if err != nil {
 		return nil, err
 	}
-	defer drainAndCloseResponseBody(resp.Body)
+	if len(addresses) == 0 {
+		nodes, err := aln.getNodesOnce(ctx, endpoint, "", false, httpState.client)
+		if err == nil && len(nodes) == 0 && endpoint.RawQuery == "" {
+			return nil, errors.New("cluster /localnodes response contains no usable live nodes")
+		}
+		return nodes, err
+	}
+
+	var errs []error
+	sawEmptyResponse := false
+	for i, address := range addresses {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
+		requestCtx, cancelRequest := fairAttemptContext(ctx, len(addresses)-i)
+		nodes, err := aln.getNodesOnce(requestCtx, endpoint, address, len(addresses) > 1, httpState.client)
+		cancelRequest()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("DNS address %s: %w", address, err))
+			continue
+		}
+		if len(nodes) == 0 {
+			sawEmptyResponse = true
+			continue
+		}
+		return nodes, nil
+	}
+	if sawEmptyResponse && endpoint.RawQuery != "" {
+		// An empty scoped response means this address has no nodes in the requested scope.
+		// Let the caller try its configured fallback scope after every address was checked.
+		return nil, nil
+	}
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
+	}
+	return nil, errors.New("all resolved DNS addresses returned no usable live nodes")
+}
+
+func (aln *AlternatorLiveNodes) discoveryTimeout() time.Duration {
+	return discoveryTimeoutForConfig(aln.cfg)
+}
+
+func discoveryTimeoutForConfig(cfg ALNConfig) time.Duration {
+	if cfg.HTTPClientTimeout > 0 {
+		return cfg.HTTPClientTimeout
+	}
+	return defaultDiscoveryTimeout
+}
+
+// resolveEndpointAddresses returns resolved socket addresses for a DNS endpoint.
+// A nil result means the configured test transport handles the logical hostname itself.
+func (aln *AlternatorLiveNodes) resolveEndpointAddresses(
+	ctx context.Context,
+	endpoint *url.URL,
+	httpState *liveNodesHTTPState,
+) ([]string, error) {
+	hostname := endpoint.Hostname()
+	if hostname == "" {
+		return nil, errors.New("discovery endpoint has no hostname")
+	}
+	if _, err := netip.ParseAddr(hostname); err == nil {
+		return nil, nil
+	}
+	if transport, ok := httpState.client.Transport.(*http.Transport); ok && transport.Proxy != nil {
+		proxyRequest := &http.Request{URL: endpoint}
+		proxyURL, err := transport.Proxy(proxyRequest)
+		if err != nil {
+			return nil, fmt.Errorf("select proxy for discovery endpoint %q: %w", endpoint.String(), err)
+		}
+		if proxyURL != nil {
+			// The proxy owns resolution of the logical endpoint. Resolving and
+			// pinning it locally would bypass or duplicate proxy semantics.
+			return nil, nil
+		}
+	}
+
+	resolver := httpState.resolver
+	if resolver == nil {
+		// Test-only RoundTripper hooks often use synthetic hostnames and intentionally bypass DNS.
+		// Production's standard transport uses the system resolver and gets address-level fallback.
+		if _, ok := httpState.client.Transport.(*http.Transport); !ok {
+			return nil, nil
+		}
+		resolver = net.DefaultResolver
+	}
+	resolved, err := resolver.LookupNetIP(ctx, "ip", hostname)
+	if err != nil {
+		return nil, fmt.Errorf("resolve DNS entrypoint %q: %w", hostname, err)
+	}
+
+	addresses := make([]string, 0, len(resolved))
+	for _, address := range resolved {
+		address = address.Unmap()
+		addresses = append(addresses, net.JoinHostPort(address.String(), endpoint.Port()))
+	}
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("resolve DNS entrypoint %q: empty answer", hostname)
+	}
+	return addresses, nil
+}
+
+func (aln *AlternatorLiveNodes) getNodesOnce(
+	ctx context.Context,
+	endpoint *url.URL,
+	resolvedAddress string,
+	closeConnection bool,
+	httpClient *http.Client,
+) ([]url.URL, error) {
+	if resolvedAddress != "" {
+		ctx = context.WithValue(ctx, dnsDialTargetContextKey{}, dnsDialTarget{
+			logicalAddress:  endpoint.Host,
+			resolvedAddress: resolvedAddress,
+		})
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// Separate resolved addresses must use separate connections. Otherwise an idle connection
+	// to a reachable-but-invalid address could be reused for every fallback attempt.
+	request.Close = closeConnection
+	resp, attemptTransport, err := aln.doDiscoveryRequest(request, resolvedAddress, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	if attemptTransport != nil {
+		defer attemptTransport.CloseIdleConnections()
+	}
+	drainResponse := true
+	defer func() {
+		if drainResponse {
+			drainAndCloseResponseBody(resp.Body)
+			return
+		}
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New("non-200 response")
+		return nil, fmt.Errorf("unexpected HTTP status %d", resp.StatusCode)
 	}
-	body, err := io.ReadAll(resp.Body)
+	if resp.Body == nil {
+		return nil, errors.New("response has no body")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryResponseBody+1))
 	if err != nil {
 		return nil, err
+	}
+	if len(body) > maxDiscoveryResponseBody {
+		drainResponse = false
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxDiscoveryResponseBody)
 	}
 
 	var nodes []string
 	if err := json.Unmarshal(body, &nodes); err != nil {
 		return nil, err
 	}
+	if nodes == nil {
+		return nil, errors.New("response must be a JSON array")
+	}
 
 	var uris []url.URL
-	for _, node := range nodes {
+	invalidNodes := 0
+	for i, node := range nodes {
+		if i%256 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		uri, err := nodeURL(aln.cfg.Scheme, node, aln.cfg.Port)
 		if err != nil {
-			aln.cfg.Logger.Error("invalid node URI", logx.A("node", node), logx.A("error", err))
+			invalidNodes++
+			if invalidNodes <= maxLoggedInvalidNodes {
+				aln.cfg.Logger.Error("invalid node URI", logx.A("node", node), logx.A("error", err))
+			}
 			continue
 		}
 		uris = append(uris, uri)
 	}
+	if invalidNodes > maxLoggedInvalidNodes {
+		aln.cfg.Logger.Error(
+			"additional invalid node URIs omitted",
+			logx.A("count", invalidNodes-maxLoggedInvalidNodes),
+		)
+	}
+	if len(nodes) != 0 && len(uris) == 0 {
+		return nil, errors.New("response contains no usable live nodes")
+	}
 	return sortNodesByAddress(uris), nil
+}
+
+func (aln *AlternatorLiveNodes) doDiscoveryRequest(
+	request *http.Request,
+	resolvedAddress string,
+	httpClient *http.Client,
+) (*http.Response, *http.Transport, error) {
+	attemptClient := *httpClient
+	attemptClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	if resolvedAddress == "" {
+		response, err := attemptClient.Do(request)
+		return response, nil, err
+	}
+
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		httpClient.CloseIdleConnections()
+		response, err := attemptClient.Do(request)
+		return response, nil, err
+	}
+	attemptTransport := transport.Clone()
+	attemptClient.Transport = attemptTransport
+	response, err := attemptClient.Do(request)
+	if err != nil {
+		attemptTransport.CloseIdleConnections()
+		return nil, nil, err
+	}
+	return response, attemptTransport, nil
 }
 
 func nodeURL(scheme, host string, port int) (url.URL, error) {
@@ -637,23 +1176,11 @@ func sortNodesByAddress(nodes []url.URL) []url.URL {
 	return nodes
 }
 
-func cloneAndDedupeNodes(nodes []url.URL) []url.URL {
-	out := make([]url.URL, 0, len(nodes))
-	seen := make(map[string]struct{}, len(nodes))
-	for _, node := range nodes {
-		key := node.String()
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, node)
-	}
-	return sortNodesByAddress(out)
-}
-
 // CheckIfRackAndDatacenterSetCorrectly verifies that the rack and datacenter
 // settings are correctly configured and recognized by the Alternator cluster.
 func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err error) {
+	ctx, cancel := context.WithTimeout(aln.ctx, aln.discoveryTimeout())
+	defer cancel()
 	var errs []error
 	defer func() {
 		if err == nil && len(errs) > 0 {
@@ -662,13 +1189,18 @@ func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err erro
 			}
 		}
 	}()
-	scope := aln.cfg.RoutingScope
-	for scope != nil {
+	scopes, err := routingScopes(aln.cfg.RoutingScope)
+	if err != nil {
+		return err
+	}
+	for i, scope := range scopes {
 		if rt.IsClusterScope(scope) {
 			// Cluster scope does not require validation
 			return nil
 		}
-		newNodes, err := aln.getNodesForScope(scope)
+		scopeCtx, cancelScope := fairAttemptContext(ctx, len(scopes)-i)
+		newNodes, err := aln.getNodesForScope(scopeCtx, scope)
+		cancelScope()
 		if err != nil {
 			return fmt.Errorf("failed to read list of nodes: %w", err)
 		}
@@ -677,7 +1209,6 @@ func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err erro
 				errs,
 				fmt.Errorf("scope %s have no nodes, datacenter or rack might be incorrect", scope.String()),
 			)
-			scope = scope.Fallback()
 			continue
 		}
 		return nil
@@ -691,14 +1222,18 @@ func (aln *AlternatorLiveNodes) CheckIfRackAndDatacenterSetCorrectly() (err erro
 // CheckIfRackDatacenterFeatureIsSupported checks whether the connected Alternator
 // cluster supports rack/datacenter-aware features.
 func (aln *AlternatorLiveNodes) CheckIfRackDatacenterFeatureIsSupported() (bool, error) {
+	ctx, cancel := context.WithTimeout(aln.ctx, aln.discoveryTimeout())
+	defer cancel()
 	baseURI := aln.nextAsURLWithPath("/localnodes", "")
 	fakeRackURI := aln.nextAsURLWithPath("/localnodes", "rack=fakeRack")
 
-	hostsWithFakeRack, err := aln.getNodes(fakeRackURI)
+	fakeCtx, cancelFake := fairAttemptContext(ctx, 2)
+	hostsWithFakeRack, err := aln.getNodes(fakeCtx, fakeRackURI)
+	cancelFake()
 	if err != nil {
 		return false, err
 	}
-	hostsWithoutRack, err := aln.getNodes(baseURI)
+	hostsWithoutRack, err := aln.getNodes(ctx, baseURI)
 	if err != nil {
 		return false, err
 	}
@@ -713,6 +1248,75 @@ func (aln *AlternatorLiveNodes) CheckIfRackDatacenterFeatureIsSupported() (bool,
 // It increases the node error score by the mapped error weight.
 func (aln *AlternatorLiveNodes) ReportNodeError(node url.URL, err error) {
 	aln.nodeHealthStore.ReportNodeError(node, err)
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	snapshot := aln.liveNodes.Load()
+	if snapshot == nil || len(*snapshot) == 0 {
+		return
+	}
+
+	aln.failureMu.Lock()
+	if aln.failureSnapshot != snapshot {
+		aln.failureSnapshot = snapshot
+		aln.failedNodes = make(map[url.URL]struct{}, len(*snapshot))
+		aln.recoveryStarted = false
+	}
+	if aln.failedNodes == nil {
+		aln.failedNodes = make(map[url.URL]struct{}, len(*snapshot))
+	}
+	if !slices.Contains(*snapshot, node) {
+		aln.failureMu.Unlock()
+		return
+	}
+	aln.failedNodes[node] = struct{}{}
+	allFailed := true
+	for _, knownNode := range *snapshot {
+		if _, failed := aln.failedNodes[knownNode]; !failed {
+			allFailed = false
+			break
+		}
+	}
+	if !allFailed || aln.recoveryStarted {
+		aln.failureMu.Unlock()
+		return
+	}
+	aln.recoveryStarted = true
+	aln.failureMu.Unlock()
+
+	go aln.refreshAfterKnownNodesFailure(snapshot)
+}
+
+// ReportNodeSuccess clears a previously observed transport failure for a node
+// in the current live-node snapshot.
+func (aln *AlternatorLiveNodes) ReportNodeSuccess(node url.URL) {
+	snapshot := aln.liveNodes.Load()
+	if snapshot == nil {
+		return
+	}
+	aln.failureMu.Lock()
+	defer aln.failureMu.Unlock()
+	if aln.failureSnapshot != snapshot {
+		aln.failureSnapshot = snapshot
+		aln.failedNodes = nil
+		aln.recoveryStarted = false
+		return
+	}
+	delete(aln.failedNodes, node)
+}
+
+func (aln *AlternatorLiveNodes) refreshAfterKnownNodesFailure(snapshot *[]url.URL) {
+	_ = aln.UpdateLiveNodes()
+
+	aln.failureMu.Lock()
+	defer aln.failureMu.Unlock()
+	if aln.failureSnapshot != snapshot {
+		return
+	}
+	aln.failureSnapshot = aln.liveNodes.Load()
+	aln.failedNodes = nil
+	aln.recoveryStarted = false
 }
 
 // TryReleaseQuarantinedNodes executes the configured callback for every quarantined node.

--- a/shared/live_nodes_discovery_fallback_test.go
+++ b/shared/live_nodes_discovery_fallback_test.go
@@ -1,0 +1,382 @@
+// Copyright ScyllaDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
+	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
+)
+
+func TestAlternatorLiveNodes_PartialLearnedNodeFailureUsesSurvivingNode(t *testing.T) {
+	t.Parallel()
+
+	var recovery atomic.Bool
+	var failedNodeRequests atomic.Int32
+	var survivingNodeRequests atomic.Int32
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.local"},
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if !recovery.Load() {
+					return resp.AlternatorNodesResponse([]string{"node-a.local", "node-b.local"}, request)
+				}
+				switch request.URL.Hostname() {
+				case "node-a.local":
+					failedNodeRequests.Add(1)
+					return nil, errors.New("node-a unavailable")
+				case "node-b.local":
+					survivingNodeRequests.Add(1)
+					return resp.AlternatorNodesResponse([]string{"node-b.local", "node-c.local"}, request)
+				case "entrypoint.local":
+					return nil, errors.New("entrypoint unavailable")
+				default:
+					return nil, errors.New("unexpected discovery node")
+				}
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("initial UpdateLiveNodes returned error: %v", err)
+	}
+	recovery.Store(true)
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("partial-failure UpdateLiveNodes returned error: %v", err)
+	}
+	if got, want := hostnames(aln.GetNodes()), []string{"node-b.local", "node-c.local"}; !slices.Equal(got, want) {
+		t.Fatalf("recovered nodes got %v, want %v", got, want)
+	}
+	if failedNodeRequests.Load() == 0 || survivingNodeRequests.Load() == 0 {
+		t.Fatalf(
+			"expected both failed and surviving learned nodes to be attempted, got failed=%d surviving=%d",
+			failedNodeRequests.Load(),
+			survivingNodeRequests.Load(),
+		)
+	}
+}
+
+func TestAlternatorLiveNodes_AllKnownNodeFailuresTriggerRecovery(t *testing.T) {
+	t.Parallel()
+
+	var recovery atomic.Bool
+	refreshStarted := make(chan struct{}, 1)
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.local"},
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if !recovery.Load() {
+					return resp.AlternatorNodesResponse([]string{"node-a.local", "node-b.local"}, request)
+				}
+				select {
+				case refreshStarted <- struct{}{}:
+				default:
+				}
+				if request.URL.Hostname() == "entrypoint.local" {
+					return resp.AlternatorNodesResponse([]string{"node-c.local"}, request)
+				}
+				return nil, errors.New("learned node unavailable")
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("initial UpdateLiveNodes returned error: %v", err)
+	}
+
+	nodes := aln.GetNodes()
+	recovery.Store(true)
+	aln.ReportNodeError(nodes[0], errors.New("first node unavailable"))
+	select {
+	case <-refreshStarted:
+		t.Fatal("one failed node triggered recovery while another node remained untried")
+	case <-time.After(20 * time.Millisecond):
+	}
+	aln.ReportNodeSuccess(nodes[0])
+	aln.ReportNodeError(nodes[1], errors.New("second node unavailable"))
+	select {
+	case <-refreshStarted:
+		t.Fatal("a stale failure triggered recovery after that node succeeded")
+	case <-time.After(20 * time.Millisecond):
+	}
+	aln.ReportNodeError(nodes[0], errors.New("first node unavailable again"))
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("all known-node failures did not trigger recovery")
+	}
+	deadline := time.Now().Add(time.Second)
+	for !slices.Equal(hostnames(aln.GetNodes()), []string{"node-c.local"}) {
+		if time.Now().After(deadline) {
+			t.Fatalf("recovery did not publish node-c.local: %v", hostnames(aln.GetNodes()))
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestAlternatorLiveNodes_MultipleSeedsContinueAfterBadSeed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		bad  func(*http.Request) (*http.Response, error)
+	}{
+		{
+			name: "transport error",
+			bad: func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("unavailable")
+			},
+		},
+		{name: "non-200", bad: func(request *http.Request) (*http.Response, error) {
+			return discoveryTestResponse(request, http.StatusServiceUnavailable, "temporary"), nil
+		}},
+		{name: "malformed", bad: func(request *http.Request) (*http.Response, error) {
+			return discoveryTestResponse(request, http.StatusOK, "malformed"), nil
+		}},
+		{name: "empty", bad: func(request *http.Request) (*http.Response, error) {
+			return discoveryTestResponse(request, http.StatusOK, "[]"), nil
+		}},
+		{name: "unusable", bad: func(request *http.Request) (*http.Response, error) {
+			return discoveryTestResponse(request, http.StatusOK, `[""]`), nil
+		}},
+		{name: "stalled", bad: func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var badRequests atomic.Int32
+			var goodRequests atomic.Int32
+			storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+			storeConfig.Disabled = true
+			aln, err := NewAlternatorLiveNodes(
+				[]string{"bad-seed.local", "good-seed.local"},
+				WithALNHTTPClientTimeout(120*time.Millisecond),
+				WithALNUpdatePeriod(0),
+				WithALNIdleUpdatePeriod(-1),
+				WithALNNodeHealthStoreConfig(storeConfig),
+				WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+					return liveNodesRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+						switch request.URL.Hostname() {
+						case "bad-seed.local":
+							badRequests.Add(1)
+							return tt.bad(request)
+						case "good-seed.local":
+							goodRequests.Add(1)
+							return resp.AlternatorNodesResponse([]string{"learned.local"}, request)
+						default:
+							return nil, errors.New("unexpected discovery node")
+						}
+					})
+				}),
+			)
+			if err != nil {
+				t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+			}
+			defer aln.Stop()
+
+			startedAt := time.Now()
+			if err := aln.UpdateLiveNodes(); err != nil {
+				t.Fatalf("UpdateLiveNodes returned error: %v", err)
+			}
+			if elapsed := time.Since(startedAt); elapsed > time.Second {
+				t.Fatalf("multi-seed fallback took %s", elapsed)
+			}
+			if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"learned.local"}) {
+				t.Fatalf("discovered nodes got %v, want [learned.local]", got)
+			}
+			if badRequests.Load() == 0 || goodRequests.Load() == 0 {
+				t.Fatalf(
+					"expected both seeds to be attempted, got bad=%d good=%d",
+					badRequests.Load(),
+					goodRequests.Load(),
+				)
+			}
+		})
+	}
+}
+
+func discoveryTestResponse(request *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    request,
+	}
+}
+
+func TestAlternatorLiveNodes_DNSFailuresRetainSeedAndRecover(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		failure func(context.Context, string) (net.Conn, error)
+	}{
+		{
+			name: "NXDOMAIN",
+			failure: func(_ context.Context, _ string) (net.Conn, error) {
+				return nil, &net.DNSError{Err: "no such host", Name: "entrypoint.test", IsNotFound: true}
+			},
+		},
+		{
+			name: "SERVFAIL",
+			failure: func(_ context.Context, _ string) (net.Conn, error) {
+				return nil, &net.DNSError{Err: "server misbehaving", Name: "entrypoint.test", IsTemporary: true}
+			},
+		},
+		{
+			name: "timeout",
+			failure: func(ctx context.Context, _ string) (net.Conn, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		},
+		{
+			name: "empty answer",
+			failure: func(_ context.Context, network string) (net.Conn, error) {
+				return resolverConnection(t, network, "entrypoint.test", nil), nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			listener, err := net.Listen("tcp4", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != "/localnodes" {
+					http.Error(w, "unexpected path", http.StatusNotFound)
+					return
+				}
+				_, _ = io.WriteString(w, `["127.0.0.1"]`)
+			}))
+			server.Listener = listener
+			server.Start()
+			defer server.Close()
+			_, port := splitServerHostPort(t, server.URL)
+
+			var recovered atomic.Bool
+			resolver := &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+					if !recovered.Load() {
+						return tt.failure(ctx, network)
+					}
+					return resolverConnection(t, network, "entrypoint.test", []string{"127.0.0.1"}), nil
+				},
+			}
+			storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+			storeConfig.Disabled = true
+			aln, err := NewAlternatorLiveNodes(
+				[]string{"entrypoint.test."},
+				WithALNPort(port),
+				WithALNHTTPClientTimeout(100*time.Millisecond),
+				WithALNUpdatePeriod(0),
+				WithALNIdleUpdatePeriod(-1),
+				WithALNDNSResolver(resolver),
+				WithALNNodeHealthStoreConfig(storeConfig),
+				WithALNHTTPTransportWrapper(func(roundTripper http.RoundTripper) http.RoundTripper {
+					transport := roundTripper.(*http.Transport)
+					transport.Proxy = nil
+					return transport
+				}),
+			)
+			if err != nil {
+				t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+			}
+			defer aln.Stop()
+
+			startedAt := time.Now()
+			if err := aln.UpdateLiveNodes(); err == nil {
+				t.Fatal("UpdateLiveNodes succeeded during DNS failure")
+			}
+			if elapsed := time.Since(startedAt); elapsed > time.Second {
+				t.Fatalf("failed DNS refresh took %s", elapsed)
+			}
+			if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"entrypoint.test."}) {
+				t.Fatalf("failed DNS refresh lost seed: %v", got)
+			}
+
+			recovered.Store(true)
+			if err := aln.UpdateLiveNodes(); err != nil {
+				t.Fatalf("recovery UpdateLiveNodes returned error: %v", err)
+			}
+			if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"127.0.0.1"}) {
+				t.Fatalf("recovered nodes got %v, want [127.0.0.1]", got)
+			}
+		})
+	}
+}
+
+func resolverConnection(t *testing.T, network, hostname string, ips []string) net.Conn {
+	t.Helper()
+	client, server := net.Pipe()
+	tcp := strings.HasPrefix(network, "tcp")
+	go serveDNSQuery(t, server, tcp, hostname, ips)
+	if tcp {
+		return client
+	}
+	return &pipePacketConn{Conn: client}
+}
+
+func TestAlternatorLiveNodes_OversizedDiscoveryResponseIsBounded(t *testing.T) {
+	t.Parallel()
+	responseBody := strings.Repeat("x", maxDiscoveryResponseBody+1)
+	aln := newLiveNodesTestClient(t, time.Second, func(request *http.Request) (*http.Response, error) {
+		return discoveryTestResponse(request, http.StatusOK, responseBody), nil
+	})
+	startedAt := time.Now()
+	err := aln.UpdateLiveNodes()
+	if err == nil || !strings.Contains(err.Error(), "response body exceeds") {
+		t.Fatalf("UpdateLiveNodes error = %v, want oversized-response error", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("oversized response validation took %s", elapsed)
+	}
+}

--- a/shared/live_nodes_refresh_test.go
+++ b/shared/live_nodes_refresh_test.go
@@ -1,0 +1,397 @@
+// Copyright ScyllaDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
+	"github.com/scylladb/alternator-client-golang/shared/rt"
+	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
+)
+
+func TestAlternatorLiveNodes_OverlappingRefreshPublishesAtomicSnapshot(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var requests atomic.Int32
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.local"},
+		WithALNRoutingScope(rt.NewDCScope("target", nil)),
+		WithALNHTTPClientTimeout(time.Second),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if requests.Add(1) == 1 {
+					close(entered)
+				}
+				select {
+				case <-release:
+					return resp.AlternatorNodesResponse([]string{"node-new-a.local", "node-new-b.local"}, request)
+				case <-request.Context().Done():
+					return nil, request.Context().Err()
+				}
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	results := make(chan error, 2)
+	go func() { results <- aln.UpdateLiveNodes() }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("first refresh did not enter transport")
+	}
+	go func() { results <- aln.UpdateLiveNodes() }()
+
+	readerStop := make(chan struct{})
+	readerErrors := make(chan error, 1)
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-readerStop:
+				return
+			default:
+			}
+			observations := [][]string{hostnames(aln.GetNodes())}
+			active, quarantined := aln.GetAllNodes()
+			all := append(slices.Clone(active), quarantined...)
+			observations = append(observations, hostnames(all))
+			plan := NewLazyQueryPlan(aln)
+			var planned []url.URL
+			for node := plan.Next(); node.Host != ""; node = plan.Next() {
+				planned = append(planned, node)
+			}
+			observations = append(observations, hostnames(planned))
+			for _, observed := range observations {
+				slices.Sort(observed)
+				if !slices.Equal(observed, []string{"entrypoint.local"}) &&
+					!slices.Equal(observed, []string{"node-new-a.local", "node-new-b.local"}) {
+					select {
+					case readerErrors <- errors.New("observed partial node snapshot: " + strings.Join(observed, ",")):
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("overlapping refreshes made %d requests before release, want 1", got)
+	}
+	close(release)
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("overlapping UpdateLiveNodes returned error: %v", err)
+		}
+	}
+	close(readerStop)
+	readers.Wait()
+	select {
+	case err := <-readerErrors:
+		t.Fatal(err)
+	default:
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("overlapping refreshes made %d requests, want one coalesced request", got)
+	}
+}
+
+func TestAlternatorLiveNodes_RefreshCancellationAndShutdownAreBounded(t *testing.T) {
+	t.Run("caller cancellation stops sole refresh", func(t *testing.T) {
+		entered := make(chan struct{})
+		exited := make(chan struct{})
+		var once sync.Once
+		aln := newLiveNodesTestClient(t, 2*time.Second, func(request *http.Request) (*http.Response, error) {
+			once.Do(func() { close(entered) })
+			<-request.Context().Done()
+			close(exited)
+			return nil, request.Context().Err()
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		result := make(chan error, 1)
+		go func() { result <- aln.UpdateLiveNodesContext(ctx) }()
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("refresh did not enter transport")
+		}
+		cancel()
+		select {
+		case err := <-result:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("UpdateLiveNodesContext error = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("caller cancellation did not unblock refresh")
+		}
+		select {
+		case <-exited:
+		case <-time.After(time.Second):
+			t.Fatal("caller cancellation did not cancel transport")
+		}
+	})
+
+	t.Run("cancelled joiner does not cancel another waiter", func(t *testing.T) {
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var requests atomic.Int32
+		aln := newLiveNodesTestClient(t, time.Second, func(request *http.Request) (*http.Response, error) {
+			if requests.Add(1) == 1 {
+				close(entered)
+			}
+			select {
+			case <-release:
+				return resp.AlternatorNodesResponse([]string{"node.local"}, request)
+			case <-request.Context().Done():
+				return nil, request.Context().Err()
+			}
+		})
+
+		first := make(chan error, 1)
+		go func() { first <- aln.UpdateLiveNodes() }()
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("first refresh did not enter transport")
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		second := make(chan error, 1)
+		go func() { second <- aln.UpdateLiveNodesContext(ctx) }()
+		cancel()
+		select {
+		case err := <-second:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("joined refresh error = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("joined refresh did not observe cancellation")
+		}
+		close(release)
+		if err := <-first; err != nil {
+			t.Fatalf("remaining refresh waiter returned error: %v", err)
+		}
+		if got := requests.Load(); got != 1 {
+			t.Fatalf("coalesced refresh requests got %d, want 1", got)
+		}
+	})
+
+	t.Run("new caller retries an abandoned generation", func(t *testing.T) {
+		entered := make(chan struct{})
+		releaseAbandoned := make(chan struct{})
+		var requests atomic.Int32
+		aln := newLiveNodesTestClient(t, time.Second, func(request *http.Request) (*http.Response, error) {
+			if requests.Add(1) == 1 {
+				close(entered)
+				// Deliberately ignore cancellation until the test releases this
+				// transport to exercise the in-flight generation handoff.
+				<-releaseAbandoned
+				return nil, request.Context().Err()
+			}
+			return resp.AlternatorNodesResponse([]string{"recovered.local"}, request)
+		})
+
+		firstCtx, cancelFirst := context.WithCancel(context.Background())
+		first := make(chan error, 1)
+		go func() { first <- aln.UpdateLiveNodesContext(firstCtx) }()
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("first refresh did not enter transport")
+		}
+		cancelFirst()
+		if err := <-first; !errors.Is(err, context.Canceled) {
+			t.Fatalf("abandoned refresh error = %v, want context.Canceled", err)
+		}
+
+		second := make(chan error, 1)
+		go func() { second <- aln.UpdateLiveNodes() }()
+		select {
+		case err := <-second:
+			t.Fatalf("new caller returned before abandoned generation unwound: %v", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+		if got := requests.Load(); got != 1 {
+			t.Fatalf("new caller overlapped abandoned generation: requests=%d", got)
+		}
+
+		close(releaseAbandoned)
+		select {
+		case err := <-second:
+			if err != nil {
+				t.Fatalf("new caller did not retry abandoned generation: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("new caller did not complete after abandoned generation unwound")
+		}
+		if got := requests.Load(); got != 2 {
+			t.Fatalf("refresh requests got %d, want abandoned plus fresh generation", got)
+		}
+		if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"recovered.local"}) {
+			t.Fatalf("recovered nodes got %v, want [recovered.local]", got)
+		}
+	})
+
+	t.Run("Stop cancels stalled DNS and is idempotent", func(t *testing.T) {
+		entered := make(chan struct{})
+		var once sync.Once
+		resolver := &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				once.Do(func() { close(entered) })
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		}
+		storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+		storeConfig.Disabled = true
+		aln, err := NewAlternatorLiveNodes(
+			[]string{"entrypoint.test"},
+			WithALNDNSResolver(resolver),
+			WithALNHTTPClientTimeout(2*time.Second),
+			WithALNNodeHealthStoreConfig(storeConfig),
+		)
+		if err != nil {
+			t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+		}
+		result := make(chan error, 1)
+		go func() { result <- aln.UpdateLiveNodes() }()
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("DNS lookup did not start")
+		}
+		aln.Stop()
+		aln.Stop()
+		aln.Start()
+		select {
+		case err := <-result:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("stopped refresh error = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Stop did not cancel stalled DNS lookup")
+		}
+	})
+}
+
+func TestAlternatorLiveNodes_SubsecondRefreshIsThrottledAndStops(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.local"},
+		WithALNUpdatePeriod(25*time.Millisecond),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return resp.AlternatorNodesResponse([]string{"entrypoint.local"}, request)
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	t.Cleanup(aln.Stop)
+
+	for range 100 {
+		_ = aln.NextNode()
+	}
+	deadline := time.Now().Add(time.Second)
+	for requests.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("burst triggered %d refreshes, want one coalesced refresh", got)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("refresh worker busy-looped: requests=%d", got)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	_ = aln.NextNode()
+	deadline = time.Now().Add(time.Second)
+	for requests.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("subsecond refresh period produced %d requests, want 2", got)
+	}
+
+	aln.Stop()
+	stoppedAt := requests.Load()
+	for range 100 {
+		_ = aln.NextNode()
+	}
+	time.Sleep(2 * 25 * time.Millisecond)
+	if got := requests.Load(); got != stoppedAt {
+		t.Fatalf("refresh worker continued after Stop: requests %d -> %d", stoppedAt, got)
+	}
+}
+
+func newLiveNodesTestClient(
+	t *testing.T,
+	timeout time.Duration,
+	roundTrip func(*http.Request) (*http.Response, error),
+) *AlternatorLiveNodes {
+	t.Helper()
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.local"},
+		WithALNHTTPClientTimeout(timeout),
+		WithALNUpdatePeriod(0),
+		WithALNIdleUpdatePeriod(-1),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(roundTrip)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	t.Cleanup(aln.Stop)
+	return aln
+}

--- a/shared/live_nodes_test.go
+++ b/shared/live_nodes_test.go
@@ -15,6 +15,8 @@
 package shared
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -25,11 +27,58 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/scylladb/alternator-client-golang/shared/nodeshealth"
 	"github.com/scylladb/alternator-client-golang/shared/rt"
+	testhelpers "github.com/scylladb/alternator-client-golang/shared/tests/helpers"
 	"github.com/scylladb/alternator-client-golang/shared/tests/resp"
 )
+
+func TestAlternatorLiveNodes_UpdateDNSResolver(t *testing.T) {
+	t.Parallel()
+
+	var oldResolverCalls atomic.Int32
+	oldResolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			oldResolverCalls.Add(1)
+			return nil, errors.New("old resolver unavailable")
+		},
+	}
+	newResolver := testhelpers.NewStaticResolver("entrypoint.test", []string{"127.0.0.1"})
+	storeConfig := nodeshealth.DefaultNodeHealthStoreConfig()
+	storeConfig.Disabled = true
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"entrypoint.test"},
+		WithALNDNSResolver(oldResolver),
+		WithALNNodeHealthStoreConfig(storeConfig),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				return resp.AlternatorNodesResponse([]string{"learned.local"}, request)
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err == nil {
+		t.Fatal("discovery unexpectedly succeeded with the old resolver")
+	}
+	if oldResolverCalls.Load() == 0 {
+		t.Fatal("old resolver was not exercised")
+	}
+
+	aln.UpdateDNSResolver(newResolver)
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("discovery with updated resolver failed: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"learned.local"}) {
+		t.Fatalf("discovered nodes got %v, want [learned.local]", got)
+	}
+}
 
 func TestAlternatorLiveNodes_RoutingScopeFallbackRetriesKnownNodes(t *testing.T) {
 	t.Parallel()
@@ -47,7 +96,7 @@ func TestAlternatorLiveNodes_RoutingScopeFallbackRetriesKnownNodes(t *testing.T)
 				}
 				switch req.URL.RawQuery {
 				case "dc=wrong":
-					return resp.AlternatorNodesResponse(nil, req)
+					return resp.AlternatorNodesResponse([]string{}, req)
 				case "dc=target":
 					fallbackRequests.Add(1)
 					return resp.AlternatorNodesResponse([]string{"node3.local"}, req)
@@ -76,6 +125,46 @@ func TestAlternatorLiveNodes_RoutingScopeFallbackRetriesKnownNodes(t *testing.T)
 	}
 	if fallbackRequests.Load() == 0 {
 		t.Fatalf("expected discovery request for fallback scope")
+	}
+}
+
+func TestAlternatorLiveNodes_RoutingScopeFallbackSurvivesAnotherSeedFailure(t *testing.T) {
+	t.Parallel()
+
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"empty-seed.local", "failing-seed.local"},
+		WithALNPort(8080),
+		WithALNRoutingScope(rt.NewDCScope("wrong", rt.NewDCScope("target", nil))),
+		WithALNHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper {
+			return liveNodesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "" || req.URL.Path == "/" {
+					return resp.HealthCheckResponse(req)
+				}
+				if req.URL.Hostname() == "failing-seed.local" {
+					return nil, errors.New("seed unavailable")
+				}
+				switch req.URL.RawQuery {
+				case "dc=wrong":
+					return resp.AlternatorNodesResponse([]string{}, req)
+				case "dc=target":
+					return resp.AlternatorNodesResponse([]string{"target-node.local"}, req)
+				default:
+					t.Fatalf("unexpected /localnodes query %q", req.URL.RawQuery)
+					return nil, nil
+				}
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	if err := aln.UpdateLiveNodes(); err != nil {
+		t.Fatalf("UpdateLiveNodes returned error: %v", err)
+	}
+	if got := hostnames(aln.GetNodes()); !slices.Equal(got, []string{"target-node.local"}) {
+		t.Fatalf("GetNodes got %v, want [target-node.local]", got)
 	}
 }
 
@@ -244,7 +333,7 @@ func TestAlternatorLiveNodes_IPv6LiteralDiscoversAndRoutesRequests(t *testing.T)
 	}
 
 	routedNode := aln.NextNode()
-	response, err := aln.httpClient.Get(routedNode.String())
+	response, err := aln.httpState.Load().client.Get(routedNode.String())
 	if err != nil {
 		t.Fatalf("request through discovered IPv6 node failed: %v", err)
 	}
@@ -361,6 +450,46 @@ func TestNewAlternatorLiveNodesRejectsMalformedHost(t *testing.T) {
 	}
 }
 
+func TestDiscoveryDNSLookupUsesFiniteDeadline(t *testing.T) {
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	aln, err := NewAlternatorLiveNodes(
+		[]string{"stalled-dns.test"},
+		WithALNDNSResolver(resolver),
+		WithALNHTTPClientTimeout(20*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer aln.Stop()
+
+	startedAt := time.Now()
+	err = aln.UpdateLiveNodes()
+	if err == nil {
+		t.Fatal("UpdateLiveNodes succeeded for a stalled DNS lookup")
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("stalled DNS lookup took %s, want at most 1s", elapsed)
+	}
+	if got := aln.discoveryTimeout(); got != 20*time.Millisecond {
+		t.Fatalf("discoveryTimeout() = %s, want 20ms", got)
+	}
+
+	defaultALN, err := NewAlternatorLiveNodes([]string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("NewAlternatorLiveNodes returned error: %v", err)
+	}
+	defer defaultALN.Stop()
+	if got := defaultALN.discoveryTimeout(); got != defaultDiscoveryTimeout {
+		t.Fatalf("default discoveryTimeout() = %s, want %s", got, defaultDiscoveryTimeout)
+	}
+}
+
 func TestAlternatorLiveNodesSkipsMalformedDiscoveredHost(t *testing.T) {
 	t.Parallel()
 
@@ -459,7 +588,7 @@ func TestAlternatorLiveNodes_CheckIfRackAndDatacenterSetCorrectlyRetriesSeedNode
 							targetRequests.Add(1)
 							return resp.AlternatorNodesResponse([]string{"dc1-node.local"}, req)
 						case "dc2-node.local":
-							return resp.AlternatorNodesResponse(nil, req)
+							return resp.AlternatorNodesResponse([]string{}, req)
 						default:
 							t.Fatalf("unexpected validation host %q", req.URL.Hostname())
 							return nil, nil

--- a/shared/nodeshealth/node_health.go
+++ b/shared/nodeshealth/node_health.go
@@ -15,6 +15,7 @@
 package nodeshealth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -109,18 +110,11 @@ func NewNodeHealthStoreBasic(
 		return nil, err
 	}
 
-	var releaseTimer *time.Timer
-	if cfg.QuarantineReleasePeriod > 0 {
-		releaseTimer = time.NewTimer(cfg.QuarantineReleasePeriod)
-	}
-
 	store := &NodeHealthStore{
-		cfg:            cfg,
-		releaseFunc:    releaseFunc,
-		initialNodes:   append([]url.URL(nil), initialNodes...),
-		nodesStatuses:  make(map[url.URL]*NodeHealthStatus, len(initialNodes)),
-		releaseTimer:   releaseTimer,
-		releaseTrigger: make(chan struct{}, 1),
+		cfg:           cfg,
+		releaseFunc:   releaseFunc,
+		initialNodes:  append([]url.URL(nil), initialNodes...),
+		nodesStatuses: make(map[url.URL]*NodeHealthStatus, len(initialNodes)),
 	}
 	empty := make([]url.URL, 0)
 	store.activeNodes.Store(&empty)
@@ -143,8 +137,13 @@ type NodeHealthStore struct {
 	activeNodes      atomic.Pointer[[]url.URL]
 	quarantinedNodes atomic.Pointer[[]url.URL]
 
-	releaseTrigger chan struct{}
-	releaseTimer   *time.Timer
+	releaseMu sync.Mutex
+
+	workerMu      sync.Mutex
+	workerRunning bool
+	workerStopped bool
+	workerCancel  context.CancelFunc
+	workerDone    chan struct{}
 }
 
 // NodeHealthStatus captures the current health data for a node.
@@ -206,6 +205,13 @@ func (e *NodeHealthStore) TryReleaseQuarantinedNodes() []url.URL {
 	if e.releaseFunc == nil {
 		return nil
 	}
+	// Coalesce overlapping foreground and periodic sweeps. This makes the
+	// configured callback concurrency a store-wide bound rather than a
+	// per-sweep bound and prevents duplicate health probes for the same nodes.
+	if !e.releaseMu.TryLock() {
+		return nil
+	}
+	defer e.releaseMu.Unlock()
 	candidates := e.GetQuarantinedNodes()
 	if len(candidates) == 0 {
 		return nil
@@ -295,14 +301,36 @@ func (e *NodeHealthStore) GetNodeStatus(node url.URL) *NodeHealthStatus {
 
 // ReleaseNode released node from quarantine
 func (e *NodeHealthStore) ReleaseNode(node url.URL) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	status := e.nodesStatuses[node]
-	if status == nil {
+	e.ReleaseNodes([]url.URL{node})
+}
+
+// ReleaseNodes atomically moves the selected tracked nodes out of quarantine.
+func (e *NodeHealthStore) ReleaseNodes(nodes []url.URL) {
+	if len(nodes) == 0 {
 		return
 	}
-	e.cfg.Scoring.Release(status)
-	e.nodesStatuses[node] = status
+	selected := make(map[url.URL]struct{}, len(nodes))
+	for _, node := range nodes {
+		selected[node] = struct{}{}
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	active := e.GetActiveNodes()
+	quarantined := make([]url.URL, 0, len(e.GetQuarantinedNodes()))
+	for _, node := range e.GetQuarantinedNodes() {
+		if _, release := selected[node]; !release {
+			quarantined = append(quarantined, node)
+			continue
+		}
+		status := e.nodesStatuses[node]
+		if status == nil {
+			continue
+		}
+		e.cfg.Scoring.Release(status)
+		active = append(active, node)
+	}
+	e.activeNodes.Store(&active)
+	e.quarantinedNodes.Store(&quarantined)
 }
 
 // AddNode registers a node in the store and places it into the appropriate pool.
@@ -347,18 +375,44 @@ func (e *NodeHealthStore) RemoveNode(node url.URL) {
 	e.quarantinedNodes.Store(&quarantined)
 }
 
-// GetAllNodes returns the active and quarantined node sets and triggers async release if configured.
-func (e *NodeHealthStore) GetAllNodes() (active, quarantined []url.URL) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	for node, status := range e.nodesStatuses {
-		if status.quarantined {
+// ReplaceNodes atomically replaces the tracked-node set while preserving health
+// status for nodes that are present in both snapshots.
+func (e *NodeHealthStore) ReplaceNodes(nodes []url.URL) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	statuses := make(map[url.URL]*NodeHealthStatus, len(nodes))
+	active := make([]url.URL, 0, len(nodes))
+	quarantined := make([]url.URL, 0, len(nodes))
+	hasNewNodes := false
+	for _, node := range nodes {
+		if _, duplicate := statuses[node]; duplicate {
+			continue
+		}
+		status := e.nodesStatuses[node]
+		if status == nil {
+			status = e.cfg.Scoring.NewStatus()
+			hasNewNodes = true
+		}
+		statuses[node] = status
+		if status.Quarantined() {
 			quarantined = append(quarantined, node)
 		} else {
 			active = append(active, node)
 		}
 	}
-	return active, quarantined
+
+	e.nodesStatuses = statuses
+	e.activeNodes.Store(&active)
+	e.quarantinedNodes.Store(&quarantined)
+	return hasNewNodes
+}
+
+// GetAllNodes returns one coherent, order-preserving node snapshot.
+func (e *NodeHealthStore) GetAllNodes() (active, quarantined []url.URL) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return cloneNodes(*e.activeNodes.Load()), cloneNodes(*e.quarantinedNodes.Load())
 }
 
 // Start starts release worker and it's timer
@@ -376,35 +430,56 @@ func (e *NodeHealthStore) startReleaseWorker() {
 		return
 	}
 
-	e.releaseTimer = time.NewTimer(e.cfg.QuarantineReleasePeriod)
-
-	go func() {
-		for range e.releaseTimer.C {
-			e.triggerReleaseWorker()
-		}
-	}()
-
-	go func() {
-		for range e.releaseTrigger {
-			e.TryReleaseQuarantinedNodes()
-		}
-	}()
-}
-
-func (e *NodeHealthStore) triggerReleaseWorker() {
-	select {
-	case e.releaseTrigger <- struct{}{}:
-	default:
+	e.workerMu.Lock()
+	if e.workerRunning || e.workerStopped {
+		e.workerMu.Unlock()
+		return
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	e.workerRunning = true
+	e.workerCancel = cancel
+	e.workerDone = done
+	e.workerMu.Unlock()
+
+	go func() {
+		defer func() {
+			close(done)
+			e.workerMu.Lock()
+			if e.workerDone == done {
+				e.workerCancel = nil
+				e.workerDone = nil
+				e.workerRunning = false
+			}
+			e.workerMu.Unlock()
+		}()
+		ticker := time.NewTicker(e.cfg.QuarantineReleasePeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if ctx.Err() != nil {
+					return
+				}
+				e.TryReleaseQuarantinedNodes()
+			}
+		}
+	}()
 }
 
 func (e *NodeHealthStore) stopReleaseWorker() {
-	if e.releaseFunc == nil || e.cfg.QuarantineReleasePeriod <= 0 {
+	e.workerMu.Lock()
+	defer e.workerMu.Unlock()
+	if e.workerStopped {
 		return
 	}
-
-	e.releaseTimer.Stop()
-	close(e.releaseTrigger)
+	e.workerStopped = true
+	if !e.workerRunning {
+		return
+	}
+	e.workerCancel()
 }
 
 func cloneNodes(orig []url.URL) []url.URL {

--- a/shared/nodeshealth/node_health_noop.go
+++ b/shared/nodeshealth/node_health_noop.go
@@ -65,6 +65,38 @@ func (n *NodeHealthNoop) RemoveNode(node url.URL) {
 	})
 }
 
+// ReplaceNodes atomically replaces the known-node snapshot.
+func (n *NodeHealthNoop) ReplaceNodes(nodes []url.URL) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	oldNodes := make(map[url.URL]struct{}, len(n.knownNodes))
+	for _, node := range n.knownNodes {
+		oldNodes[node] = struct{}{}
+	}
+	replacement := make([]url.URL, 0, len(nodes))
+	seen := make(map[url.URL]struct{}, len(nodes))
+	hasNewNodes := false
+	for _, node := range nodes {
+		if _, duplicate := seen[node]; duplicate {
+			continue
+		}
+		seen[node] = struct{}{}
+		replacement = append(replacement, node)
+		if _, exists := oldNodes[node]; !exists {
+			hasNewNodes = true
+		}
+	}
+	n.knownNodes = replacement
+	return hasNewNodes
+}
+
+// GetAllNodes returns one consistent snapshot; health tracking is disabled.
+func (n *NodeHealthNoop) GetAllNodes() (active, quarantined []url.URL) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return cloneNodes(n.knownNodes), nil
+}
+
 // ReportNodeError is a no-op since health tracking is disabled.
 func (n *NodeHealthNoop) ReportNodeError(_ url.URL, _ error) {}
 

--- a/shared/nodeshealth/node_health_test.go
+++ b/shared/nodeshealth/node_health_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"slices"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -116,6 +118,153 @@ func TestNodeHealthStoreGetNodeStatusReturnsSnapshot(t *testing.T) {
 	if after.Updated().IsZero() {
 		t.Fatalf("expected stored update timestamp to stay unchanged")
 	}
+}
+
+func TestNodeHealthStoresReplaceNodesAtomically(t *testing.T) {
+	t.Parallel()
+
+	nodeA := url.URL{Scheme: "http", Host: "node-a:8080"}
+	nodeB := url.URL{Scheme: "http", Host: "node-b:8080"}
+	nodeC := url.URL{Scheme: "http", Host: "node-c:8080"}
+
+	t.Run("basic preserves retained status", func(t *testing.T) {
+		t.Parallel()
+		store, err := NewNodeHealthStoreBasic(DefaultNodeHealthStoreConfig(), nil, []url.URL{nodeA, nodeB})
+		if err != nil {
+			t.Fatal(err)
+		}
+		retainedStatus := store.GetNodeStatus(nodeB)
+		if retainedStatus == nil {
+			t.Fatal("missing retained-node status")
+		}
+		if !store.ReplaceNodes([]url.URL{nodeB, nodeC}) {
+			t.Fatal("replacement did not report new node")
+		}
+		if store.GetNodeStatus(nodeA) != nil {
+			t.Fatal("removed node still has status")
+		}
+		if got := store.GetNodeStatus(nodeB); got == nil || got.Updated() != retainedStatus.Updated() {
+			t.Fatalf("retained status changed from %v to %v", retainedStatus, got)
+		}
+		_, quarantined := store.GetAllNodes()
+		if !sameNodeSet(quarantined, []url.URL{nodeB, nodeC}) {
+			t.Fatalf("quarantined snapshot got %v", quarantined)
+		}
+		if store.ReplaceNodes([]url.URL{nodeB, nodeC}) {
+			t.Fatal("identical replacement reported a new node")
+		}
+	})
+
+	t.Run("disabled replaces one snapshot", func(t *testing.T) {
+		t.Parallel()
+		store := NewNodeHealthNoop([]url.URL{nodeA, nodeB})
+		if !store.ReplaceNodes([]url.URL{nodeB, nodeC}) {
+			t.Fatal("replacement did not report new node")
+		}
+		active, quarantined := store.GetAllNodes()
+		if !slices.Equal(active, []url.URL{nodeB, nodeC}) || len(quarantined) != 0 {
+			t.Fatalf("snapshot got active=%v quarantined=%v", active, quarantined)
+		}
+		if store.ReplaceNodes([]url.URL{nodeB, nodeC}) {
+			t.Fatal("identical replacement reported a new node")
+		}
+	})
+}
+
+func TestNodeHealthStoreReleaseWorkerRepeatsAndStopsIdempotently(t *testing.T) {
+	t.Parallel()
+
+	node := url.URL{Scheme: "http", Host: "node-worker:8080"}
+	var probes atomic.Int32
+	cfg := DefaultNodeHealthStoreConfig()
+	cfg.QuarantineReleasePeriod = 5 * time.Millisecond
+	store, err := NewNodeHealthStoreBasic(cfg, func(url.URL, NodeHealthStatus) bool {
+		probes.Add(1)
+		return false
+	}, []url.URL{node})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Start()
+	store.Start()
+	deadline := time.Now().Add(time.Second)
+	for probes.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := probes.Load(); got < 2 {
+		t.Fatalf("release worker made %d probes, want at least 2", got)
+	}
+	store.Stop()
+	store.Stop()
+	time.Sleep(20 * time.Millisecond)
+	afterStop := probes.Load()
+	time.Sleep(20 * time.Millisecond)
+	if got := probes.Load(); got != afterStop {
+		t.Fatalf("release worker continued after Stop: %d -> %d probes", afterStop, got)
+	}
+}
+
+func TestNodeHealthStoreCoalescesOverlappingReleaseSweeps(t *testing.T) {
+	t.Parallel()
+
+	node := url.URL{Scheme: "http", Host: "node-release:8080"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var probes atomic.Int32
+	store, err := NewNodeHealthStoreBasic(
+		DefaultNodeHealthStoreConfig(),
+		func(url.URL, NodeHealthStatus) bool {
+			probes.Add(1)
+			close(started)
+			<-release
+			return false
+		},
+		[]url.URL{node},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := make(chan []url.URL, 1)
+	go func() { first <- store.TryReleaseQuarantinedNodes() }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first release sweep did not start")
+	}
+
+	second := make(chan []url.URL, 1)
+	go func() { second <- store.TryReleaseQuarantinedNodes() }()
+	select {
+	case released := <-second:
+		if len(released) != 0 {
+			t.Fatalf("coalesced sweep released %v", released)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overlapping release sweep did not coalesce")
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("overlapping sweeps ran %d callbacks, want 1", got)
+	}
+
+	close(release)
+	select {
+	case <-first:
+	case <-time.After(time.Second):
+		t.Fatal("first release sweep did not finish")
+	}
+}
+
+func sameNodeSet(got, want []url.URL) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for _, node := range want {
+		if !slices.Contains(got, node) {
+			return false
+		}
+	}
+	return true
 }
 
 func TestNodeHealthStoreResetsScoreAfterInterval(t *testing.T) {

--- a/shared/query_plan.go
+++ b/shared/query_plan.go
@@ -26,6 +26,10 @@ type nodesSource interface {
 	GetQuarantinedNodes() []url.URL
 }
 
+type nodesSnapshotSource interface {
+	GetAllNodes() (active, quarantined []url.URL)
+}
+
 // LazyQueryPlan lazily materializes a list of nodes to execute a request against.
 // It defers fetching active and quarantined nodes from the source until the first
 // time they are needed by Next().
@@ -37,6 +41,7 @@ type LazyQueryPlan struct {
 	preferredNodes   []url.URL
 	sortNodes        bool
 	deterministic    bool
+	snapshotLoaded   bool
 }
 
 // NewLazyQueryPlan constructs a plan bound to the provided nodes source.
@@ -92,9 +97,7 @@ func FirstNodeWithSeed(nodes []url.URL, seed int64) url.URL {
 // quarantined nodes, picking a random node from the remaining pool and removing it
 // so that a node is never returned twice. If no nodes remain, it returns the zero url.URL.
 func (p *LazyQueryPlan) Next() url.URL {
-	if p.activeNodes == nil {
-		p.activeNodes = p.prepareNodes(p.nodes.GetActiveNodes())
-	}
+	p.loadSnapshot()
 	for len(p.preferredNodes) > 0 {
 		preferredNode := p.preferredNodes[0]
 		p.preferredNodes = p.preferredNodes[1:]
@@ -109,14 +112,26 @@ func (p *LazyQueryPlan) Next() url.URL {
 		return p.pickAndRemove(&p.activeNodes)
 	}
 
-	if p.quarantinedNodes == nil {
-		p.quarantinedNodes = p.prepareNodes(p.nodes.GetQuarantinedNodes())
-	}
 	if len(p.quarantinedNodes) > 0 {
 		return p.pickAndRemove(&p.quarantinedNodes)
 	}
 
 	return url.URL{}
+}
+
+func (p *LazyQueryPlan) loadSnapshot() {
+	if p.snapshotLoaded {
+		return
+	}
+	p.snapshotLoaded = true
+	if source, ok := p.nodes.(nodesSnapshotSource); ok {
+		active, quarantined := source.GetAllNodes()
+		p.activeNodes = p.prepareNodes(active)
+		p.quarantinedNodes = p.prepareNodes(quarantined)
+		return
+	}
+	p.activeNodes = p.prepareNodes(p.nodes.GetActiveNodes())
+	p.quarantinedNodes = p.prepareNodes(p.nodes.GetQuarantinedNodes())
 }
 
 func (p *LazyQueryPlan) pickAndRemove(nodes *[]url.URL) url.URL {

--- a/shared/tests/helpers/dns.go
+++ b/shared/tests/helpers/dns.go
@@ -1,0 +1,147 @@
+// Copyright ScyllaDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"slices"
+	"strings"
+	"time"
+)
+
+// NewStaticResolver returns an in-memory DNS resolver for deterministic tests.
+func NewStaticResolver(hostname string, addresses []string) *net.Resolver {
+	addresses = slices.Clone(addresses)
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(_ context.Context, network, _ string) (net.Conn, error) {
+			client, server := net.Pipe()
+			tcp := strings.HasPrefix(network, "tcp")
+			go serveDNSQuery(server, tcp, hostname, addresses)
+			if tcp {
+				return client, nil
+			}
+			return &packetConn{Conn: client}, nil
+		},
+	}
+}
+
+type packetConn struct {
+	net.Conn
+}
+
+func (c *packetConn) ReadFrom(buffer []byte) (int, net.Addr, error) {
+	n, err := c.Read(buffer)
+	return n, c.RemoteAddr(), err
+}
+
+func (c *packetConn) WriteTo(buffer []byte, _ net.Addr) (int, error) {
+	return c.Write(buffer)
+}
+
+func serveDNSQuery(conn net.Conn, tcp bool, hostname string, addresses []string) {
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	query := make([]byte, 2048)
+	n, err := conn.Read(query)
+	if err != nil {
+		return
+	}
+	query = query[:n]
+	if tcp {
+		response, err := dnsResponse(query[2:], hostname, addresses)
+		if err != nil {
+			return
+		}
+		framed := make([]byte, len(response)+2)
+		binary.BigEndian.PutUint16(framed[:2], uint16(len(response)))
+		copy(framed[2:], response)
+		_, _ = conn.Write(framed)
+		return
+	}
+	response, err := dnsResponse(query, hostname, addresses)
+	if err != nil {
+		return
+	}
+	_, _ = conn.Write(response)
+}
+
+func dnsResponse(query []byte, hostname string, addresses []string) ([]byte, error) {
+	if len(query) < 17 {
+		return nil, errors.New("short DNS query")
+	}
+	offset := 12
+	var labels []string
+	for {
+		if offset >= len(query) {
+			return nil, errors.New("truncated DNS name")
+		}
+		length := int(query[offset])
+		offset++
+		if length == 0 {
+			break
+		}
+		if offset+length > len(query) {
+			return nil, errors.New("truncated DNS label")
+		}
+		labels = append(labels, string(query[offset:offset+length]))
+		offset += length
+	}
+	if offset+4 > len(query) {
+		return nil, errors.New("truncated DNS question")
+	}
+	if strings.Join(labels, ".") != hostname {
+		return nil, errors.New("unexpected DNS hostname")
+	}
+	questionEnd := offset + 4
+	queryType := binary.BigEndian.Uint16(query[offset : offset+2])
+
+	var answers [][]byte
+	for _, value := range addresses {
+		ip := net.ParseIP(value)
+		var record []byte
+		switch queryType {
+		case 1:
+			record = ip.To4()
+		case 28:
+			if ip.To4() == nil {
+				record = ip.To16()
+			}
+		}
+		if record != nil {
+			answers = append(answers, record)
+		}
+	}
+
+	response := make([]byte, 12, 12+questionEnd-12+len(answers)*28)
+	copy(response[:2], query[:2])
+	binary.BigEndian.PutUint16(response[2:4], 0x8180)
+	binary.BigEndian.PutUint16(response[4:6], 1)
+	binary.BigEndian.PutUint16(response[6:8], uint16(len(answers)))
+	response = append(response, query[12:questionEnd]...)
+	for _, answer := range answers {
+		header := make([]byte, 12)
+		binary.BigEndian.PutUint16(header[0:2], 0xc00c)
+		binary.BigEndian.PutUint16(header[2:4], queryType)
+		binary.BigEndian.PutUint16(header[4:6], 1)
+		binary.BigEndian.PutUint16(header[10:12], uint16(len(answer)))
+		response = append(response, header...)
+		response = append(response, answer...)
+	}
+	return response, nil
+}

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -15,10 +15,20 @@
 package shared
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"net"
 	"net/http"
+	"time"
 )
+
+type dnsDialTargetContextKey struct{}
+
+type dnsDialTarget struct {
+	logicalAddress  string
+	resolvedAddress string
+}
 
 // DefaultHTTPTransport creates default `http.Transport`
 func DefaultHTTPTransport() *http.Transport {
@@ -42,6 +52,22 @@ func PatchHTTPTransport(config ALNConfig, transport *http.Transport) http.RoundT
 	transport.IdleConnTimeout = config.IdleHTTPConnectionTimeout
 	transport.MaxIdleConns = config.MaxIdleHTTPConnections
 	transport.MaxIdleConnsPerHost = config.MaxIdleHTTPConnectionsPerHost
+	originalDialContext := transport.DialContext
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Resolver:  config.DNSResolver,
+	}
+	if originalDialContext == nil || config.DNSResolver != nil {
+		originalDialContext = dialer.DialContext
+	}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if target, ok := ctx.Value(dnsDialTargetContextKey{}).(dnsDialTarget); ok &&
+			address == target.logicalAddress {
+			address = target.resolvedAddress
+		}
+		return originalDialContext(ctx, network, address)
+	}
 
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}


### PR DESCRIPTION
## Summary

Implements the Go portion of DRIVER-815 / DRIVER-818 for resilient DNS entrypoint discovery and active-session recovery.

- Resolves each logical DNS entrypoint on every discovery cycle and tries resolved socket addresses independently.
- Preserves the logical scheme, hostname, port, HTTP Host, TLS SNI/certificate validation, proxy behavior, and SigV4 signing while connecting to alternate addresses.
- Retains immutable configured seeds so learned-node failure can re-resolve the original entrypoint and learn a fresh node set.
- Keeps active-session recovery in `AlternatorLiveNodes`: transports report success or failure for the selected node, and the shared manager starts one bounded, coalesced refresh only after every node in the current snapshot has failed.
- Clears stale failure observations when a node succeeds, so partial or historical failures do not trigger unnecessary discovery.
- Uses the existing discovery path for recovery: try learned nodes first, then original seed/DNS entrypoints, re-resolve DNS, and atomically publish the recovered snapshot.
- Continues across connection errors, resets, timeouts, non-2xx responses, redirects, malformed JSON, empty results, and unusable node data.
- Coalesces overlapping refreshes and health sweeps and bounds DNS, connection, response, validation, cancellation, and shutdown work.
- Exposes `WithDNSResolver` in shared configuration and both SDK adapters for deterministic resolution and custom resolver use.

The SDK adapters use their ordinary `LazyQueryPlan`; they contain no discovery-refresh policy or request-attempt recovery hooks.

## Scenario coverage

1. First DNS record broken, later record reachable.
2. Several leading DNS records broken.
3. Active session loses every learned node and triggers shared recovery.
4. Recovery returns to the original seed, re-resolves, relearns, and continues.
5. Partial learned-node failure does not trigger recovery while another node remains usable.
6. Successful operations clear stale failure observations.
7. All DNS records unavailable fail clearly and within configured bounds.
8. Reset, timeout, transport error, redirect, and non-2xx `/localnodes` failures advance to another address.
9. Malformed, empty, `null`, or unusable `/localnodes` data advances or fails clearly.
10. Routing-scope fallback continues through reachable entrypoints.
11. Normal operations after recovery use learned nodes, not the seed endpoint.
12. NXDOMAIN, SERVFAIL, DNS timeout, and empty answers retain the seed for later recovery.
13. Recovery uses changed or reordered DNS answers.
14. A bad configured seed does not block another seed.
15. Host, TLS, proxy, and SigV4 logical-host semantics survive address fallback.
16. Concurrent refresh, cancellation, shutdown, and publication behavior remains bounded and atomic.

## Validation

- `make check`
- `make test-unit`
- Focused shared and SDK recovery tests repeated 100 times under `-race`

No dependency or toolchain changes are included.

Jira task: https://scylladb.atlassian.net/browse/DRIVER-818  
Jira epic: https://scylladb.atlassian.net/browse/DRIVER-815

Fixes #147
