### PR TITLE
PM-350: migrate call_jira_sync.yml to the consolidated workflow on main

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -10,32 +10,9 @@ permissions:
   issues: write
 
 jobs:
-  jira-sync-pr-opened:
-    if: github.event.action == 'opened' || github.event.action == 'edited'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
-    secrets:
-      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
-
-  jira-sync-in-review:
-    if: github.event.action == 'ready_for_review' || github.event.action == 'review_requested'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
-    secrets:
-      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
-
-  jira-sync-add-label:
-    if: github.event.action == 'labeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
-    secrets:
-      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
-
-  jira-sync-remove-label:
-    if: github.event.action == 'unlabeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
-    secrets:
-      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
-
-  jira-sync-pr-closed:
-    if: github.event.action == 'closed'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@9cb06b4c28233ca6b922ed8d26b9ba2da1dedb48 # main 2026-06-23
+  jira-sync:
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@main
+    with:
+      caller_action: ${{ github.event.action }}
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
This repository still used the older five-job layout, with all five `uses:` lines pinned to commit `9cb06b4` — so fixes merged to `scylladb/github-automation` main never reached it.

Per PM-336 this migrates to the consolidated workflow and references `@main`:

- the five per-event jobs (`pr_opened` / `in_review` / `add_label` / `remove_label` / `pr_closed`) collapse into a single `jira-sync` job calling `main_pr_events_jira_sync.yml@main`;
- the raw `github.event.action` is passed as the `caller_action` input, and the script resolves the correct handler.

**Event coverage is unchanged.** `EVENT_ACTION_MAP` in `jira_sync_logic.py` groups the same seven actions exactly as the five old jobs did:

| action | old job | handler |
|---|---|---|
| `opened`, `edited` | jira-sync-pr-opened | `manage_opened_gh_event` |
| `ready_for_review`, `review_requested` | jira-sync-in-review | `manage_review_gh_event` |
| `labeled` | jira-sync-add-label | `manage_labeled_gh_event` |
| `unlabeled` | jira-sync-remove-label | `manage_unlabeled_gh_event` |
| `closed` | jira-sync-pr-closed | `manage_closed_gh_event` |

The `on:` trigger list, `permissions:` and the `USER_AND_KEY_FOR_JIRA_AUTOMATION` secret are unchanged, so no new repository configuration is required.

Fixes: PM-350

Part of PM-336.